### PR TITLE
Added logging support using the standard python module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ doc/html
 doc/index.rst
 run_vitables.py
 
+build

--- a/scripts/vitables
+++ b/scripts/vitables
@@ -28,12 +28,17 @@ import locale
 from optparse import OptionParser
 import sys
 import os.path
+import logging
 
 import sip
 sip.setapi('QString', 2)
 sip.setapi('QVariant', 2)
 
 from PyQt4 import QtGui
+
+_VERBOSITY_LOGLEVEL_DICT = {0: logging.ERROR, 1: logging.WARNING,
+                            2: logging.INFO, 3: logging.DEBUG}
+_FILE_LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 
 def main(args):
     """The application launcher.
@@ -78,12 +83,36 @@ def main(args):
     parser.add_option('-d', '--dblist', dest='dblist',
         help='a file with the list of databases to be open', metavar='h5list')
     parser.set_defaults(mode='a', dblist='')
+    # logging options
+    parser.add_option('-l', '--log-file', help='log file path')
+    parser.add_option('-v', '--verbose', action='count', default=0,
+                      help='log verbosity level')
+    # parse and process options
     (options, h5files) = parser.parse_args()
     if options.dblist:
         # Other options and positional arguments are silently ignored
         options.mode = ''
         h5files = []
-
+    # setup top level logger using command line options
+    logger = logging.getLogger('vitables')
+    file_formatter = logging.Formatter(_FILE_LOG_FORMAT)
+    temporary_stderr_handler = logging.StreamHandler()
+    temporary_stderr_handler.setFormatter(file_formatter)
+    logger.addHandler(temporary_stderr_handler)
+    if options.log_file is not None:
+        log_filename = os.path.expandvars(os.path.expanduser(options.log_file))
+        # TODO(alexey) add checks that the file can be written into,
+        # add a function into utils maybe
+        file_handler = logging.FileHandler(log_filename)
+        file_handler.setFormatter(file_formatter)
+        logger.addHandler(file_handler)
+    if options.verbose in _VERBOSITY_LOGLEVEL_DICT:
+        logger.setLevel(_VERBOSITY_LOGLEVEL_DICT[options.verbose])
+    else:
+        logger.setLevel(logging.ERROR)
+        logger.error('Invalid verbosity level: {}'.format(options.verbose))
+    # remove stderr handler, by default use logger.Logger object
+    logger.removeHandler(temporary_stderr_handler)
     # Start the application
     vtapp = VTApp(mode=options.mode, dblist=options.dblist, h5files=h5files)
     vtapp.gui.show()

--- a/vitables/logger.py
+++ b/vitables/logger.py
@@ -117,6 +117,11 @@ class Logger(QtGui.QTextEdit):
         self.moveCursor(QtGui.QTextCursor.EndOfLine)
         self.setTextColor(current_color)
 
+    def flush(self):
+        """
+        Stopgap function to allow use of this class with logging.StreamHandler.
+        """
+        pass
 
     def createCustomContextMenu(self, pos):
         """

--- a/vitables/vtGUI.py
+++ b/vitables/vtGUI.py
@@ -27,6 +27,7 @@ toolbars, statusbars and `QActions` bound to both menus and toolbars.
 __docformat__ = 'restructuredtext'
 
 import sys
+import logging
 
 from PyQt4 import QtCore
 from PyQt4 import QtGui
@@ -37,6 +38,7 @@ import vitables.vtsplash
 
 translate = QtGui.QApplication.translate
 
+_GUI_LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 
 class VTGUI(QtGui.QMainWindow):
     """
@@ -128,6 +130,11 @@ class VTGUI(QtGui.QMainWindow):
 
         # Put the logging console in the bottom region of the window
         self.logger = logger.Logger(self.vsplitter)
+        # add self.logger as handler of main logger object
+        vitables_logger = logging.getLogger('vitables')
+        stream_handler = logging.StreamHandler(self.logger)
+        stream_handler.setFormatter(logging.Formatter(_GUI_LOG_FORMAT))
+        vitables_logger.addHandler(stream_handler)
 
         # The signal mapper used to keep the the Window menu updated
         self.window_mapper = QtCore.QSignalMapper(self)


### PR DESCRIPTION
Hi,

It seems that using standard python logging facilities is better way of storing runtime info. So I went ahead and added logging stuff to vitables. Basically now one can log using something like

``` python
logger = logging.getLogger('vitables')
logger.info('Some message')
```

Logs will go to main gui logger.Logger object and optionally to a file specified on command line. Log level is set by providing different number of -v options.
1. Added command line options for selecting a log file and setting
   a log level. ERROR level is used by default, -vvv selects DEBUG log level.
2. Updated logger.Logger class so that it can be used with
   logging.StreamHandler
3. Set VTGUI.logger as stream handler for logging.
4. Added build directory to gitignore.

Alexey
