### PR TITLE
Allow mdi subwindow handle context menu event.

### DIFF
--- a/vitables/vtgui.py
+++ b/vitables/vtgui.py
@@ -905,8 +905,17 @@ class VTGUI(QtGui.QMainWindow):
 
         if widget == self.workspace:
             if event.type() == QtCore.QEvent.ContextMenu:
-                pos = event.globalPos()
-                self.mdi_cm.popup(pos)
+                # if active mdi subwindow can handle context menu
+                # event pass envent to it
+                active_window = self.workspace.activeSubWindow()
+                if active_window is not None \
+                   and hasattr(active_window, 'is_context_menu_custom'):
+                    is_cm_custom = active_window.is_context_menu_custom
+                else:
+                    is_cm_custom = False
+                if not is_cm_custom:
+                    pos = event.globalPos()
+                    self.mdi_cm.popup(pos)
             return QtGui.QMdiArea.eventFilter(widget, widget, event)
         else:
             return QtGui.QMainWindow.eventFilter(self, widget, event)


### PR DESCRIPTION
ViTables handles context menu event for mdi subwindows. Thus there is no obvious way to write a plugin that creates custom data view and requires left mouse button events (for example data plot). To solve this problem I changed `eventFilter()` in `vtgui`. It was intercepting and handling context menu events inside mdi area. I added additional check: if there is an active subwindow object, it has the field `is_context_menu_custom` and it is set to true then the event is passed to the object. Thus context menu works as before for the build in stuff but this event can be handled by a plugin if it creates an mdi subwindow. 
