### PR TITLE
BUG: Fixed issue #38.

### DIFF
--- a/vitables/preferences/pluginsloader.py
+++ b/vitables/preferences/pluginsloader.py
@@ -212,8 +212,10 @@ class PluginsLoader(object):
                          format(mod_name))
             return
         except KeyError:
-            LOGGER.error('\nError:  plugin {0} can not be found'.
-                         format(mod_name))
+            # Print UID instead of mod_name, because the mod_name is not
+            # defined in case of a KeyError.
+            LOGGER.error('\nError:  plugin with UID {0} can not be found'.
+                         format(UID))
             return
 
         # Retrieve the plugin class


### PR DESCRIPTION
ViTables could not start because of wrong exception handling. The try-catch block handling the `KeyError` in `load` used a not instantiated variable. Now instead of printing the non-existent `mod_name`, the `UID` of the missing plug-in is used.