### PR TITLE
Update deprecated PyTables syntax

### DIFF
--- a/vitables/docbrowser/browsergui.py
+++ b/vitables/docbrowser/browsergui.py
@@ -276,7 +276,7 @@ class HelpBrowserGUI(QtGui.QMainWindow) :
             history_toolbar)
         history_toolbar.addWidget(go_selector)
         self.combo_history = QtGui.QComboBox(history_toolbar)
-        self.combo_history.setSizeAdjustPolicy(\
+        self.combo_history.setSizeAdjustPolicy(
             QtGui.QComboBox.AdjustToContents)
         history_toolbar.addWidget(self.combo_history)
 
@@ -289,8 +289,7 @@ class HelpBrowserGUI(QtGui.QMainWindow) :
         controller, :meth:`vitables.docbrowser.helpbrowser.HelpBrowser`.
         """
 
-        self.combo_history.activated[str].connect(\
-            self.browser.displaySrc)
+        self.combo_history.activated[str].connect(self.browser.displaySrc)
 
         # This is the most subtle connection. It encompasses source
         # changes coming from anywhere, including slots (home, backward
@@ -298,10 +297,10 @@ class HelpBrowserGUI(QtGui.QMainWindow) :
         # programatic changes (setSource calls).
         self.text_browser.sourceChanged.connect(self.browser.updateHistory)
 
-        self.text_browser.backwardAvailable.connect(\
+        self.text_browser.backwardAvailable.connect(
             self.browser.updateBackward)
 
-        self.text_browser.forwardAvailable.connect(\
+        self.text_browser.forwardAvailable.connect(
             self.browser.updateForward)
 
         # The Bookmarks menu is special case due to its dynamic nature.

--- a/vitables/docbrowser/helpbrowser.py
+++ b/vitables/docbrowser/helpbrowser.py
@@ -267,7 +267,7 @@ class HelpBrowser(QtCore.QObject) :
         Shows a message box with the application `About` info.
         """
 
-        QtGui.QMessageBox.information(self.gui, \
+        QtGui.QMessageBox.information(self.gui,
             translate('HelpBrowser', 'About HelpBrowser', 'A dialog caption'),
             translate('HelpBrowser', """<html><h3>HelpBrowser</h3>
                 HelpBrowser is a very simple tool for displaying the HTML

--- a/vitables/h5db/dbdoc.py
+++ b/vitables/h5db/dbdoc.py
@@ -147,7 +147,7 @@ class DBDoc(QtCore.QObject):
 
         return file_format
 
-    def getNode(self, where):
+    def get_node(self, where):
         """
         The node whose path is where.
 
@@ -155,7 +155,7 @@ class DBDoc(QtCore.QObject):
         """
 
         try:
-            node = self.h5file.getNode(where)
+            node = self.h5file.get_node(where)
             return node
         except tables.exceptions.NoSuchNodeError:
             self.logger.error(
@@ -165,15 +165,15 @@ class DBDoc(QtCore.QObject):
             vitables.utils.formatExceptionInfo()
             return None
 
-    def listNodes(self):
+    def list_nodes(self):
         """:Returns: the recursive list of full nodepaths for the file"""
-        return [node._v_pathname for node in self.h5file.walkNodes('/')]
+        return [node._v_pathname for node in self.h5file.walk_nodes('/')]
 
     #
     # Editing databases
     #
 
-    def copyFile(self, dst_filepath):
+    def copy_file(self, dst_filepath):
         """
         Copy the contents of this file to another one.
 
@@ -190,7 +190,7 @@ class DBDoc(QtCore.QObject):
         """
 
         try:
-            self.h5file.copyFile(dst_filepath, overwrite=True)
+            self.h5file.copy_file(dst_filepath, overwrite=True)
         except tables.exceptions.HDF5ExtError:
             self.logger.error(
                 translate('DBDoc',
@@ -208,5 +208,5 @@ class DBDoc(QtCore.QObject):
 
         group_name = '_p_' + str(uuid.uuid4())
         self.hidden_group = '/' + group_name
-        self.h5file.createGroup('/', group_name, 'Hide cut nodes')
+        self.h5file.create_group('/', group_name, 'Hide cut nodes')
         self.h5file.flush()

--- a/vitables/h5db/dbstreemodel.py
+++ b/vitables/h5db/dbstreemodel.py
@@ -189,7 +189,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
 
         # Check the file format
         try:
-            if not tables.isHDF5File(filepath):
+            if not tables.is_hdf5_file(filepath):
                 error = translate('DBsTreeModel', \
                     'Opening cancelled: file {0} has not HDF5 format.',
                     'A logger error message').format(filepath)
@@ -246,7 +246,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
         for row, child in enumerate(self.root.children):
             if child.filepath == filepath:
                 # Deletes the node from the tree of databases model/view
-                self.removeRows(row)
+                self.remove_rows(row)
 
                 # If needed, refresh the copied node info
                 try:
@@ -258,7 +258,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
                 # Close the hdf5 file
                 db_doc = self.getDBDoc(filepath)
                 if db_doc.hidden_group is not None:
-                    db_doc.h5file.removeNode(db_doc.hidden_group,
+                    db_doc.h5file.remove_node(db_doc.hidden_group,
                                              recursive=True)
                 db_doc.closeH5File()
                 # Update the dictionary of open files
@@ -342,7 +342,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
             # Deletes the node from the tree of databases model/view
             parent = self.parent(index)
             position = node.row()
-            self.removeRows(position, parent=parent)
+            self.remove_rows(position, parent=parent)
 
             # If needed, refresh the copied node info. This info must
             # not be cleared when pasting a CUT node overwrites other
@@ -358,7 +358,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
             QtGui.qApp.restoreOverrideCursor()
 
 
-    def copyNode(self, index):
+    def copy_node(self, index):
         """Mark a node from the tree of databases view as copied.
 
         :Parameter index: the index of the selected node
@@ -399,7 +399,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
             # Deletes the node from the tree of databases model/view
             parent = self.parent(index)
             position = index.row()
-            self.removeRows(position, parent=parent)
+            self.remove_rows(position, parent=parent)
             # If position > 0 then the above sibling will be selected
             # else the parent group will be selected
             if position == 0:
@@ -463,9 +463,9 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
             basename = self.ccni['nodename']
             src_nodepath = '{0}/{1}'.format(dirname, basename)
 
-        return self.getDBDoc(src_filepath).getNode(src_nodepath)
+        return self.getDBDoc(src_filepath).get_node(src_nodepath)
 
-    def createGroup(self, index, childname, overwrite=False):
+    def create_group(self, index, childname, overwrite=False):
         """Create a `tables.Group` under the given parent.
 
         :Parameters:
@@ -484,7 +484,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
                 self.overwriteNode(parent, index, childname)
 
             # Create the group in the PyTables database
-            parent.editor().createGroup(parent.nodepath, childname)
+            parent.editor().create_group(parent.nodepath, childname)
 
             # Paste the node in the tree of databases model/view
             self.lazyAddChildren(index)
@@ -495,7 +495,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
         finally:
             QtGui.qApp.restoreOverrideCursor()
 
-    def renameNode(self, index, new_name, overwrite=False):
+    def rename_node(self, index, new_name, overwrite=False):
         """Rename a node.
 
         :Parameters:
@@ -578,7 +578,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
                             (child_node.filepath, child_node.nodepath),
                             QtCore.Qt.StatusTipRole)
 
-    def moveNode(self, src_filepath, childpath, parent_index, overwrite=False):
+    def move_node(self, src_filepath, childpath, parent_index, overwrite=False):
         """Move a `tables.Node` to a different location.
 
         :Parameters:
@@ -610,7 +610,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
                 self.overwriteNode(parent_node, parent_index, nodename)
 
             # Move the node to the PyTables database
-            pt_node = self.getDBDoc(src_filepath).getNode(childpath)
+            pt_node = self.getDBDoc(src_filepath).get_node(childpath)
             db_doc = self.getDBDoc(src_filepath)
             if hasattr(pt_node, 'target'):
                 editor = tlink_editor.TLinkEditor(db_doc)
@@ -635,7 +635,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
 
         nodename = os.path.basename(childpath)
         dst_dbdoc = self.getDBDoc(dst_filepath)
-        parent = dst_dbdoc.getNode(parentpath)
+        parent = dst_dbdoc.get_node(parentpath)
         sibling = getattr(parent, '_v_children').keys()
 
         # Nodename pattern
@@ -912,7 +912,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
             group = self.nodeFromIndex(parent)
             try:
                 node = group.childAtRow(row)
-                return self.createIndex(row, column, node)
+                return self.create_index(row, column, node)
             except IndexError:
                 return QtCore.QModelIndex()
         return QtCore.QModelIndex()
@@ -944,7 +944,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
             return QtCore.QModelIndex()
         grandparent = parent.parent
         row = grandparent.rowOfChild(parent)
-        return self.createIndex(row, 0, parent)
+        return self.create_index(row, 0, parent)
 
     def lazyAddChildren(self, index):
         """Add children to a group node when it is expanded.
@@ -1031,7 +1031,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
         return True
 
 
-    def removeRows(self, position, count=1, parent=QtCore.QModelIndex()):
+    def remove_rows(self, position, count=1, parent=QtCore.QModelIndex()):
         """Removes `count` rows before the given row.
 
         This method is called when an item is cut/deleted/D&D.
@@ -1191,12 +1191,12 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
                 return False
 
             # Move the node to its final destination in the PyTables database
-            new_name = self.moveNode(filepath, nodepath, parent)
+            new_name = self.move_node(filepath, nodepath, parent)
             if new_name is None:
                 return False
 
             # Remove the dragged node from the model
-            self.removeRows(initial_row, parent=initial_parent)
+            self.remove_rows(initial_row, parent=initial_parent)
 
 
             # If needed, refresh the copied node info

--- a/vitables/h5db/dbstreemodel.py
+++ b/vitables/h5db/dbstreemodel.py
@@ -349,8 +349,8 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
             # node
             try:
                 if self.ccni['is_copied'] and \
-                        (self.ccni['filepath'] == node.filepath) and
-                         self.ccni['nodepath'].startswith(node.nodepath):
+                        (self.ccni['filepath'] == node.filepath) and \
+                        self.ccni['nodepath'].startswith(node.nodepath):
                     self.ccni = {}
             except KeyError:
                 pass
@@ -912,7 +912,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
             group = self.nodeFromIndex(parent)
             try:
                 node = group.childAtRow(row)
-                return self.create_index(row, column, node)
+                return self.createIndex(row, column, node)
             except IndexError:
                 return QtCore.QModelIndex()
         return QtCore.QModelIndex()
@@ -944,7 +944,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
             return QtCore.QModelIndex()
         grandparent = parent.parent
         row = grandparent.rowOfChild(parent)
-        return self.create_index(row, 0, parent)
+        return self.createIndex(row, 0, parent)
 
     def lazyAddChildren(self, index):
         """Add children to a group node when it is expanded.

--- a/vitables/h5db/dbstreemodel.py
+++ b/vitables/h5db/dbstreemodel.py
@@ -190,7 +190,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
         # Check the file format
         try:
             if not tables.is_hdf5_file(filepath):
-                error = translate('DBsTreeModel', \
+                error = translate('DBsTreeModel',
                     'Opening cancelled: file {0} has not HDF5 format.',
                     'A logger error message').format(filepath)
                 self.logger.error(error)
@@ -349,8 +349,8 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
             # node
             try:
                 if self.ccni['is_copied'] and \
-                (self.ccni['filepath'] == node.filepath) and \
-                self.ccni['nodepath'].startswith(node.nodepath):
+                        (self.ccni['filepath'] == node.filepath) and
+                         self.ccni['nodepath'].startswith(node.nodepath):
                     self.ccni = {}
             except KeyError:
                 pass
@@ -574,9 +574,9 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
                             QtCore.Qt.StatusTipRole)
             else:
                 self.setData(child_index,
-                            '{0}->{1}'.format\
-                            (child_node.filepath, child_node.nodepath),
-                            QtCore.Qt.StatusTipRole)
+                             '{0}->{1}'.format(child_node.filepath,
+                                               child_node.nodepath),
+                             QtCore.Qt.StatusTipRole)
 
     def move_node(self, src_filepath, childpath, parent_index, overwrite=False):
         """Move a `tables.Node` to a different location.
@@ -828,8 +828,8 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
         - `role`: the role of the header section being inspected
         """
 
-        if (orientation, role) == (QtCore.Qt.Horizontal, \
-            QtCore.Qt.DisplayRole):
+        if (orientation, role) == (QtCore.Qt.Horizontal,
+                                   QtCore.Qt.DisplayRole):
             return translate('DBsTreeModel',
                 'Tree of databases',
                 'Header of the only column of the tree of databases view')

--- a/vitables/h5db/dbstreeview.py
+++ b/vitables/h5db/dbstreeview.py
@@ -140,9 +140,9 @@ class DBsTreeView(QtGui.QTreeView):
         """
 
         modifiers = QtGui.QApplication.keyboardModifiers()
-        if (modifiers & QtCore.Qt.ShiftModifier) \
-           or (modifiers & QtCore.Qt.ControlModifier):
-            return
+        if (modifiers & QtCore.Qt.ShiftModifier) or \
+                (modifiers & QtCore.Qt.ControlModifier):
+           return
         node = self.dbt_model.nodeFromIndex(index)
         if node.node_kind.count('group'):
             if not self.isExpanded(index):
@@ -297,7 +297,7 @@ class DBsTreeView(QtGui.QTreeView):
 
         mime_data = event.mimeData()
         if mime_data.hasFormat('text/uri-list'):
-            if self.dbt_model.dropMimeData(\
+            if self.dbt_model.dropMimeData(
                 mime_data, QtCore.Qt.CopyAction, -1, -1, self.currentIndex()):
                 event.setDropAction(QtCore.Qt.CopyAction)
                 event.accept()

--- a/vitables/h5db/groupnode.py
+++ b/vitables/h5db/groupnode.py
@@ -54,7 +54,7 @@ class GroupNode(object):
         self.updated = False
         self.children = []
         self.parent = parent
-        self.node = parent.node._f_getChild(name)
+        self.node = parent.node._f_get_child(name)
         self.node_kind = 'group'
 
         self.has_view = False

--- a/vitables/h5db/leafnode.py
+++ b/vitables/h5db/leafnode.py
@@ -53,7 +53,7 @@ class LeafNode(object):
 
         self.dbt_model = model
         self.parent = parent
-        self.node = parent.node._f_getChild(name)
+        self.node = parent.node._f_get_child(name)
 
         self.has_view = False
 

--- a/vitables/h5db/linknode.py
+++ b/vitables/h5db/linknode.py
@@ -53,7 +53,7 @@ class LinkNode(object):
 
         self.dbt_model = model
         self.parent = parent
-        self.node = parent.node._f_getChild(name)
+        self.node = parent.node._f_get_child(name)
 
         self.has_view = False
 

--- a/vitables/h5db/nodeitemdelegate.py
+++ b/vitables/h5db/nodeitemdelegate.py
@@ -116,7 +116,7 @@ class NodeItemDelegate(QtGui.QItemDelegate):
             return
 
         # Update the underlying data structure
-        model.renameNode(index, nodename, overwrite)
+        model.rename_node(index, nodename, overwrite)
         self.closeEditor.emit(editor, 0)
 
         # Update the application status bar

--- a/vitables/h5db/rootgroupnode.py
+++ b/vitables/h5db/rootgroupnode.py
@@ -62,7 +62,7 @@ class RootGroupNode(object):
         self.filepath = None
         self.node_kind = 'root group'
         if data_source:
-            self.node = data_source.getNode('/')
+            self.node = data_source.get_node('/')
 
             self.has_view = False
 

--- a/vitables/h5db/tlink_editor.py
+++ b/vitables/h5db/tlink_editor.py
@@ -64,7 +64,7 @@ class TLinkEditor(object):
         """
 
         try:
-            link = self.h5file.getNode(nodepath)
+            link = self.h5file.get_node(nodepath)
             link.remove()
             self.h5file.flush()
         except (tables.NodeError, OSError):
@@ -88,10 +88,10 @@ class TLinkEditor(object):
         nodename = os.path.basename(nodepath)
         try:
             # The hidden group should contain at most 1 node
-            for node in self.h5file.listNodes(self.hidden_group):
+            for node in self.h5file.list_nodes(self.hidden_group):
                 self.h5file.deleteNode(node._v_pathname)
 
-            link = self.h5file.getNode(nodepath)
+            link = self.h5file.get_node(nodepath)
             link.move(newparent=self.hidden_group, newname=nodename)
             self.h5file.flush()
         except(tables.NodeError, OSError):
@@ -127,7 +127,7 @@ class TLinkEditor(object):
         """
 
         try:
-            link = self.h5file.getNode(nodepath)
+            link = self.h5file.get_node(nodepath)
             link.rename(new_name)
             self.h5file.flush()
         except (tables.NodeError, OSError):
@@ -147,15 +147,15 @@ class TLinkEditor(object):
 
         try:
             dst_h5file = dst_dbdoc.h5file
-            parent_node = dst_h5file.getNode(parentpath)
-            link = self.h5file.getNode(childpath)
+            parent_node = dst_h5file.get_node(parentpath)
+            link = self.h5file.get_node(childpath)
             if self.h5file is dst_h5file:
                 link.move(newparent=parentpath, newname=childname)
             else:
                 link.copy(newparent=parent_node, newname=childname)
                 dst_h5file.flush()
                 src_where, src_nodename = os.path.split(childpath)
-                self.h5file.removeNode(src_where, src_nodename, recursive=1)
+                self.h5file.remove_node(src_where, src_nodename, recursive=1)
             self.h5file.flush()
             return childname
         except (tables.NodeError, OSError):

--- a/vitables/h5db/tnode_editor.py
+++ b/vitables/h5db/tnode_editor.py
@@ -64,7 +64,7 @@ class TNodeEditor(object):
         """
 
         try:
-            self.h5file.removeNode(where=nodepath, recursive=True)
+            self.h5file.remove_node(where=nodepath, recursive=True)
             self.h5file.flush()
         except (tables.NodeError, OSError):
             vitables.utils.formatExceptionInfo()
@@ -87,7 +87,7 @@ class TNodeEditor(object):
         nodename = os.path.basename(nodepath)
         try:
             # The hidden group should contain at most 1 node
-            for node in self.h5file.listNodes(self.hidden_group):
+            for node in self.h5file.list_nodes(self.hidden_group):
                 self.delete(node._v_pathname)
 
             self.move(nodepath, self, self.hidden_group, nodename)
@@ -107,7 +107,7 @@ class TNodeEditor(object):
         """
 
         try:
-            self.h5file.copyNode(src_node, newparent=parent,
+            self.h5file.copy_node(src_node, newparent=parent,
                 newname=childname, overwrite=True, recursive=True)
             self.h5file.flush()
         except (tables.NodeError, OSError):
@@ -127,13 +127,13 @@ class TNodeEditor(object):
         where, current_name = os.path.split(nodepath)
 
         try:
-            self.h5file.renameNode(where, new_name, current_name, overwrite=1)
+            self.h5file.rename_node(where, new_name, current_name, overwrite=1)
             self.h5file.flush()
         except (tables.NodeError, OSError):
             vitables.utils.formatExceptionInfo()
 
 
-    def createGroup(self, where, final_name):
+    def create_group(self, where, final_name):
         """
         Create a new group under the given location.
 
@@ -144,9 +144,9 @@ class TNodeEditor(object):
         """
 
         try:
-            if final_name in self.h5file.getNode(where)._v_children.keys():
-                self.h5file.removeNode(where, final_name, recursive=True)
-            self.h5file.createGroup(where, final_name, title='')
+            if final_name in self.h5file.get_node(where)._v_children.keys():
+                self.h5file.remove_node(where, final_name, recursive=True)
+            self.h5file.create_group(where, final_name, title='')
             self.h5file.flush()
         except (tables.NodeError, OSError):
             vitables.utils.formatExceptionInfo()
@@ -165,16 +165,16 @@ class TNodeEditor(object):
 
         try:
             dst_h5file = dst_dbdoc.h5file
-            parent_node = dst_h5file.getNode(parentpath)
+            parent_node = dst_h5file.get_node(parentpath)
             if self.h5file is dst_h5file:
-                self.h5file.moveNode(childpath, newparent=parent_node,
+                self.h5file.move_node(childpath, newparent=parent_node,
                     newname=childname, overwrite=True)
             else:
-                self.h5file.copyNode(childpath, newparent=parent_node,
+                self.h5file.copy_node(childpath, newparent=parent_node,
                     newname=childname, overwrite=True, recursive=True)
                 dst_h5file.flush()
                 src_where, src_nodename = os.path.split(childpath)
-                self.h5file.removeNode(src_where, src_nodename, recursive=1)
+                self.h5file.remove_node(src_where, src_nodename, recursive=1)
             self.h5file.flush()
             return childname
         except (tables.NodeError, OSError):

--- a/vitables/nodeprops/attreditor.py
+++ b/vitables/nodeprops/attreditor.py
@@ -289,7 +289,7 @@ class AttrEditor(object):
                                         for row in self.edited_attrs.keys()])
         for attr in (all_attrs - edited_attrs_names):
             try:
-                self.asi._v_node._f_delAttr(attr)
+                self.asi._v_node._f_delattr(attr)
             except (tables.NodeError, AttributeError):
                 vitables.utils.formatExceptionInfo()
 

--- a/vitables/nodeprops/attrpropdlg.py
+++ b/vitables/nodeprops/attrpropdlg.py
@@ -106,7 +106,7 @@ class AttrPropDlg(QtGui.QDialog, Ui_AttrPropDialog):
         self.sattrLE.setText(str(len(info.system_attrs)))
 
         # Table of system attributes
-        self.sysTable.horizontalHeader().setResizeMode(\
+        self.sysTable.horizontalHeader().setResizeMode(
             QtGui.QHeaderView.Stretch)
         self.sysattr_model = QtGui.QStandardItemModel()
         self.sysattr_model.setHorizontalHeaderLabels([
@@ -235,8 +235,8 @@ class AttrPropDlg(QtGui.QDialog, Ui_AttrPropDialog):
                     value_item.setText(str(value)[1:-1])
             # ViTables doesn't support editing ND-array attributes so
             # they are displayed in non editable cells
-            if (hasattr(value, 'shape') and value.shape != ())or\
-            (info.mode == 'read-only'):
+            if (hasattr(value, 'shape') and value.shape != ()) or \
+                    info.mode == 'read-only':
                 editable = False
                 brush = bg_brush
             else:

--- a/vitables/nodeprops/leafproppage.py
+++ b/vitables/nodeprops/leafproppage.py
@@ -134,9 +134,9 @@ class LeafPropPage(QtGui.QWidget, Ui_LeafPropPage):
                         translate('LeafPropPage', '-'))
                 else:
                     pathname_item = QtGui.QStandardItem(str(pathname))
-                    type_item = QtGui.QStandardItem(\
+                    type_item = QtGui.QStandardItem(
                             str(info.columns_types[pathname]))
-                    shape_item = QtGui.QStandardItem(\
+                    shape_item = QtGui.QStandardItem(
                                         str(info.columns_shapes[pathname]))
                 self.fields_model.appendRow([pathname_item, type_item,
                                             shape_item])

--- a/vitables/plugins/csv/import_csv.py
+++ b/vitables/plugins/csv/import_csv.py
@@ -173,8 +173,7 @@ def heterogeneousTableInfo(input_handler, first_line, data):
                 temp_file.seek(0)
                 idata = numpy.genfromtxt(temp_file, delimiter=',',
                                          usecols=(field,), dtype=None)
-                itemsizes[field] = \
-                    max(itemsizes[field], idata.dtype.itemsize)
+                itemsizes[field] = max(itemsizes[field], idata.dtype.itemsize)
                 del idata
             temp_file.close()
             buf = read_fh(buf_size)
@@ -254,7 +253,7 @@ def homogeneousTableInfo(input_handler, first_line, data):
                           for i in indices])
     else:
         if data.dtype.name.startswith('string'):
-            descr = dict([('f{0}'.format(field), tables.StringCol(itemsize)) 
+            descr = dict([('f{0}'.format(field), tables.StringCol(itemsize))
                           for field in indices])
         else:
             descr = dict([('f{0}'.format(field),

--- a/vitables/plugins/csv/import_csv.py
+++ b/vitables/plugins/csv/import_csv.py
@@ -634,7 +634,7 @@ class ImportCSV(QtCore.QObject):
             dataset_name = "imported_{0}".format(kind)
             atitle = \
                 'Source CSV file {0}'.format(os.path.basename(filepath))
-            dataset = dbdoc.h5file.createTable(
+            dataset = dbdoc.h5file.create_table(
                 '/', dataset_name, descr, title=atitle, filters=io_filters,
                 expectedrows=nrows)
             # Fill the dataset in a memory efficient way
@@ -687,7 +687,7 @@ class ImportCSV(QtCore.QObject):
             io_filters = tables.Filters(complevel=9, complib='lzo')
             dataset_name = "imported_{0}".format(kind)
             atitle = 'Source CSV file {0}'.format(os.path.basename(filepath))
-            dataset = dbdoc.h5file.createEArray(
+            dataset = dbdoc.h5file.create_earray(
                 '/', dataset_name, atom, array_shape, title=atitle,
                 filters=io_filters, expectedrows=nrows)
 
@@ -740,7 +740,7 @@ class ImportCSV(QtCore.QObject):
             io_filters = tables.Filters(complevel=9, complib='lzo')
             dataset_name = "imported_{0}".format(kind)
             atitle = 'Source CSV file {0}'.format(os.path.basename(filepath))
-            dataset = dbdoc.h5file.createCArray(
+            dataset = dbdoc.h5file.create_carray(
                 '/', dataset_name, atom, array_shape, title=atitle,
                 filters=io_filters)
 
@@ -801,7 +801,7 @@ class ImportCSV(QtCore.QObject):
                 array_name = "imported_{0}".format(kind)
                 title = 'Imported from CSV file {0}'.\
                     format(os.path.basename(filepath))
-                dbdoc.h5file.createArray('/', array_name, data, title=title)
+                dbdoc.h5file.create_array('/', array_name, data, title=title)
                 dbdoc.h5file.flush()
                 self.updateTree(dbdoc.filepath)
             except TypeError:

--- a/vitables/plugins/dbstreesort/aboutpage.py
+++ b/vitables/plugins/dbstreesort/aboutpage.py
@@ -30,7 +30,10 @@ dialog selector pane.
 __docformat__ = 'restructuredtext'
 
 import os.path
-import configparser
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 
 from PyQt4 import QtGui
 from PyQt4.uic import loadUiType

--- a/vitables/plugins/dbstreesort/aboutpage.py
+++ b/vitables/plugins/dbstreesort/aboutpage.py
@@ -113,8 +113,7 @@ class AboutPage(QtGui.QWidget, Ui_DBsTreeSortPage):
         combobox are lost.
         """
 
-        self.config['DBsTreeSorting']['algorithm'] = \
-            self.initial_sorting
+        self.config['DBsTreeSorting']['algorithm'] = self.initial_sorting
         with open(self.ini_filename, 'w') as ini_file:
             self.config.write(ini_file)
         #self.preferences_dlg.reject()

--- a/vitables/plugins/dbstreesort/dbs_tree_sort.py
+++ b/vitables/plugins/dbstreesort/dbs_tree_sort.py
@@ -32,7 +32,10 @@ comment = 'Sorts the display of the databases tree'
 
 import os
 import re
-import configparser
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 
 from PyQt4 import QtGui
 from PyQt4 import QtCore

--- a/vitables/plugins/timeseries/aboutpage.py
+++ b/vitables/plugins/timeseries/aboutpage.py
@@ -30,8 +30,11 @@ dialog selector tree.
 __docformat__ = 'restructuredtext'
 
 import os.path
-import configparser
 import datetime
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 
 from PyQt4 import QtGui
 from PyQt4 import QtCore

--- a/vitables/plugins/timeseries/time_series.py
+++ b/vitables/plugins/timeseries/time_series.py
@@ -87,20 +87,20 @@ def findTS(leaf, node_kind):
         coltypes = leaf.coltypes
         # Check for Pandas timeseries
         if pd and hasattr(attrs, 'index_kind') and \
-        (attrs.index_kind in ('datetime64', 'datetime32')):
+                (attrs.index_kind in ('datetime64', 'datetime32')):
             return 'pandas_ts'
         # Check for scikits.timeseries timeseries
         if ts and hasattr(attrs, 'CLASS') and \
-        (attrs.CLASS == 'TimeSeriesTable'):
+                (attrs.CLASS == 'TimeSeriesTable'):
             return 'scikits_ts'
         # Check for PyTables timeseries
         for name in leaf.colnames:
             if (name in coltypes) and (coltypes[name] in time_types):
                 return 'pytables_ts'
     elif (leaf.atom.type in time_types) and \
-    (len(leaf.shape) < 3) and \
-    (leaf.atom.shape == ()) and \
-    (node_kind != 'vlarray'):
+            (len(leaf.shape) < 3) and \
+            (leaf.atom.shape == ()) and \
+            (node_kind != 'vlarray'):
         return 'pytables_ts'
     else:
         return None

--- a/vitables/plugins/timeseries/time_series.py
+++ b/vitables/plugins/timeseries/time_series.py
@@ -32,7 +32,10 @@ comment = 'Display time series in a human friendly format'
 
 import time
 import os
-import configparser
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 
 import tables
 

--- a/vitables/preferences/preferences.py
+++ b/vitables/preferences/preferences.py
@@ -110,7 +110,7 @@ class Preferences(QtGui.QDialog, Ui_SettingsDialog):
         self.resetPreferences()
 
         # Connect SIGNALS to SLOTS
-        self.buttonsBox.helpRequested.connect(\
+        self.buttonsBox.helpRequested.connect(
             QtGui.QWhatsThis.enterWhatsThisMode)
 
 
@@ -237,7 +237,7 @@ class Preferences(QtGui.QDialog, Ui_SettingsDialog):
         else:
             self.lastDirCB.setChecked(False)
 
-        self.restoreCB.setChecked(\
+        self.restoreCB.setChecked(
             self.initial_prefs['Startup/restoreLastSession'])
 
         # Style page
@@ -251,8 +251,7 @@ class Preferences(QtGui.QDialog, Ui_SettingsDialog):
         self.workspaceLabel.setStyleSheet('background-color: {0}'.
             format(self.initial_prefs['Workspace/Background'].color().name()))
 
-        index = self.stylesCB.findText(\
-            self.initial_prefs['Look/currentStyle'])
+        index = self.stylesCB.findText(self.initial_prefs['Look/currentStyle'])
         self.stylesCB.setCurrentIndex(index)
 
         # The visual update done above is not enough, we must reset the
@@ -435,7 +434,7 @@ class Preferences(QtGui.QDialog, Ui_SettingsDialog):
             about_page = pg_instance.helpAbout(self.stackedPages)
         except AttributeError:
             about_page = QtGui.QWidget(self.stackedPages)
-            label = QtGui.QLabel(translate(\
+            label = QtGui.QLabel(translate(
                 'Preferences',
                 'Sorry, there are no info available for this plugin',
                 'A text label'), about_page)

--- a/vitables/queries/query.py
+++ b/vitables/queries/query.py
@@ -118,11 +118,9 @@ class Query(QtCore.QObject):
         # the indices of the rows selected in the source table so a new
         # description dictionary is needed. Int64 values are necessary
         # to keep full 64-bit indices
-        ft_dict = \
-            {self.qdescr['indices_field_name']: \
-            tables.Int64Col(pos=-1)}
+        ft_dict = {self.qdescr['indices_field_name']: tables.Int64Col(pos=-1)}
         ft_dict.update(src_dict)
-        f_table = self.tmp_h5file.create_table(\
+        f_table = self.tmp_h5file.create_table(
             '/_p_query_results',
             self.qdescr['ft_name'],
             ft_dict,
@@ -139,7 +137,7 @@ class Query(QtCore.QObject):
             lstop = lstart + chunk_size
             if lstop > stop:
                 lstop = stop
-            coordinates = self.table.get_where_list(\
+            coordinates = self.table.get_where_list(
                 self.qdescr['condition'],
                 self.qdescr['condvars'],
                 start=lstart, stop=lstop, step=step)
@@ -147,9 +145,9 @@ class Query(QtCore.QObject):
             if selection.shape == (0, ):
                 continue
 
-            coord_dtype = numpy.dtype(\
+            coord_dtype = numpy.dtype(
                 [(str(self.qdescr['indices_field_name']), '<i8')])
-            new_dtype = numpy.dtype(\
+            new_dtype = numpy.dtype(
                 coord_dtype.descr + selection.dtype.descr)
 
             new_buffer = numpy.empty(selection.shape, dtype=new_dtype)
@@ -161,7 +159,7 @@ class Query(QtCore.QObject):
             self.flushTable(f_table)
 
         # Move the intermediate table to its final destination
-        self.tmp_h5file.move_node(\
+        self.tmp_h5file.move_node(
             '/_p_query_results/' + self.qdescr['ft_name'],
             '/', newname=self.qdescr['ft_name'],
             overwrite=True)
@@ -178,7 +176,7 @@ class Query(QtCore.QObject):
         div = numpy.divide(stop - start, chunk_size)
 
         # Create the destination table
-        f_table = self.tmp_h5file.create_table(\
+        f_table = self.tmp_h5file.create_table(
             '/_p_query_results',
             self.qdescr['ft_name'],
             src_dict,
@@ -195,7 +193,7 @@ class Query(QtCore.QObject):
             lstop = lstart + chunk_size
             if lstop > stop:
                 lstop = stop
-            selection = self.table.read_where(\
+            selection = self.table.read_where(
                 self.qdescr['condition'],
                 self.qdescr['condvars'],
                 start=lstart, stop=lstop, step=step)
@@ -203,7 +201,7 @@ class Query(QtCore.QObject):
             self.flushTable(f_table)
 
         # Move the intermediate table to its final destination
-        self.tmp_h5file.move_node(\
+        self.tmp_h5file.move_node(
             '/_p_query_results/' + self.qdescr['ft_name'],
             '/', newname=self.qdescr['ft_name'],
             overwrite=True)
@@ -224,7 +222,7 @@ class Query(QtCore.QObject):
                 self.queryWithNoIndex(src_dict)
         except KeyError:
             vitables.utils.formatExceptionInfo()
-            self.tmp_h5file.remove_node(\
+            self.tmp_h5file.remove_node(
                 '/_p_query_results/' + self.qdescr['ft_name'])
         else:
             self.tmp_h5file.flush()

--- a/vitables/queries/query.py
+++ b/vitables/queries/query.py
@@ -122,7 +122,7 @@ class Query(QtCore.QObject):
             {self.qdescr['indices_field_name']: \
             tables.Int64Col(pos=-1)}
         ft_dict.update(src_dict)
-        f_table = self.tmp_h5file.createTable(\
+        f_table = self.tmp_h5file.create_table(\
             '/_p_query_results',
             self.qdescr['ft_name'],
             ft_dict,
@@ -139,11 +139,11 @@ class Query(QtCore.QObject):
             lstop = lstart + chunk_size
             if lstop > stop:
                 lstop = stop
-            coordinates = self.table.getWhereList(\
+            coordinates = self.table.get_where_list(\
                 self.qdescr['condition'],
                 self.qdescr['condvars'],
                 start=lstart, stop=lstop, step=step)
-            selection = self.table.readCoordinates(coordinates)
+            selection = self.table.read_coordinates(coordinates)
             if selection.shape == (0, ):
                 continue
 
@@ -161,7 +161,7 @@ class Query(QtCore.QObject):
             self.flushTable(f_table)
 
         # Move the intermediate table to its final destination
-        self.tmp_h5file.moveNode(\
+        self.tmp_h5file.move_node(\
             '/_p_query_results/' + self.qdescr['ft_name'],
             '/', newname=self.qdescr['ft_name'],
             overwrite=True)
@@ -178,7 +178,7 @@ class Query(QtCore.QObject):
         div = numpy.divide(stop - start, chunk_size)
 
         # Create the destination table
-        f_table = self.tmp_h5file.createTable(\
+        f_table = self.tmp_h5file.create_table(\
             '/_p_query_results',
             self.qdescr['ft_name'],
             src_dict,
@@ -195,7 +195,7 @@ class Query(QtCore.QObject):
             lstop = lstart + chunk_size
             if lstop > stop:
                 lstop = stop
-            selection = self.table.readWhere(\
+            selection = self.table.read_where(\
                 self.qdescr['condition'],
                 self.qdescr['condvars'],
                 start=lstart, stop=lstop, step=step)
@@ -203,7 +203,7 @@ class Query(QtCore.QObject):
             self.flushTable(f_table)
 
         # Move the intermediate table to its final destination
-        self.tmp_h5file.moveNode(\
+        self.tmp_h5file.move_node(\
             '/_p_query_results/' + self.qdescr['ft_name'],
             '/', newname=self.qdescr['ft_name'],
             overwrite=True)
@@ -215,7 +215,7 @@ class Query(QtCore.QObject):
         """
 
         try:
-            src_dict = self.table.description._v_colObjects
+            src_dict = self.table.description._v_colobjects
             # Add an `indexes` column to the result table
             if self.qdescr['indices_field_name']:
                 self.queryWithIndex(src_dict)
@@ -224,7 +224,7 @@ class Query(QtCore.QObject):
                 self.queryWithNoIndex(src_dict)
         except KeyError:
             vitables.utils.formatExceptionInfo()
-            self.tmp_h5file.removeNode(\
+            self.tmp_h5file.remove_node(\
                 '/_p_query_results/' + self.qdescr['ft_name'])
         else:
             self.tmp_h5file.flush()

--- a/vitables/queries/querydlg.py
+++ b/vitables/queries/querydlg.py
@@ -361,7 +361,7 @@ class QueryDlg(QtGui.QDialog, Ui_QueryDialog):
 
         syntax_ok = True
         try:
-            self.source_table.willQueryUseIndexing(condition, self.condvars)
+            self.source_table.will_query_use_indexing(condition, self.condvars)
         except SyntaxError as error:
             syntax_ok = False
             self.logger.error(error.__doc__)

--- a/vitables/utils.py
+++ b/vitables/utils.py
@@ -353,12 +353,12 @@ def createIcons(large_icons, small_icons, icons_dict):
     for name in all_icons:
         icon = QtGui.QIcon()
         if name in large_icons:
-            pixmap = QtGui.QPixmap(\
+            pixmap = QtGui.QPixmap(
                 os.path.join(ICONDIR, '22x22', '{0}.png').format(name))
             pixmap.scaled(QtCore.QSize(22, 22), QtCore.Qt.KeepAspectRatio)
             icon.addPixmap(pixmap, QtGui.QIcon.Normal, QtGui.QIcon.On)
         if name in small_icons:
-            pixmap = QtGui.QPixmap(\
+            pixmap = QtGui.QPixmap(
                 os.path.join(ICONDIR,'16x16', '{0}.png').format(name))
             icon.addPixmap(pixmap, QtGui.QIcon.Normal, QtGui.QIcon.On)
         icons_dict[name] = icon
@@ -367,8 +367,8 @@ def createIcons(large_icons, small_icons, icons_dict):
     icons_dict[''] = QtGui.QIcon()
 
     # Application icon
-    icons_dict['vitables_wm'] = QtGui.QIcon(\
-        os.path.join(ICONDIR,'vitables_wm.png'))
+    icons_dict['vitables_wm'] = QtGui.QIcon(
+        os.path.join(ICONDIR, 'vitables_wm.png'))
 
 
 def getIcons():

--- a/vitables/vtapp.py
+++ b/vitables/vtapp.py
@@ -515,7 +515,7 @@ class VTApp(QtCore.QObject):
                 filename_in_sibling = trier_filename in sibling
                 del dialog
                 if (overwrite == True) and (not is_initial_filepath) and \
-                    (not is_tmp_filepath):
+                        (not is_tmp_filepath):
                     break
             else:
                 del dialog
@@ -628,9 +628,9 @@ class VTApp(QtCore.QObject):
 
         # Open the database and select it in the tree view
         if self.gui.dbs_tree_model.openDBDoc(filepath, mode, position):
-            self.gui.dbs_tree_view.setCurrentIndex(\
-                self.gui.dbs_tree_model.index(\
-                position, 0, QtCore.QModelIndex()))
+            self.gui.dbs_tree_view.setCurrentIndex(
+                self.gui.dbs_tree_model.index(
+                    position, 0, QtCore.QModelIndex()))
             self.updateRecentFiles(filepath, mode)
 
 
@@ -802,7 +802,7 @@ class VTApp(QtCore.QObject):
         parent = self.gui.dbs_tree_model.nodeFromIndex(current)
 
         # Get the new group name
-        dialog = nodenamedlg.InputNodeName(\
+        dialog = nodenamedlg.InputNodeName(
             translate('VTApp', 'Creating a new group', 'A dialog caption'),
             translate('VTApp', 'Source file: {0}\nParent group: {1}\n\n ',
                 'A dialog label').format(parent.filepath, parent.nodepath),
@@ -859,7 +859,7 @@ class VTApp(QtCore.QObject):
         parent = child.parent
 
         # Get the new nodename
-        dialog = nodenamedlg.InputNodeName(\
+        dialog = nodenamedlg.InputNodeName(
             translate('VTApp', 'Renaming a node', 'A dialog caption'),
             translate('VTApp', 'Source file: {0}\nParent group: {1}\n\n',
                 'A dialog label').format(parent.filepath, parent.nodepath),
@@ -975,7 +975,7 @@ class VTApp(QtCore.QObject):
             # - target is the source's parent
             if (cni['filepath'] == parent.filepath):
                 if (cni['nodepath'] == parent.nodepath) or \
-                (parent.nodepath == os.path.dirname(cni['nodepath'])):
+                        (parent.nodepath == os.path.dirname(cni['nodepath'])):
                     return
 
         # Soft links cannot be pasted in external files
@@ -1271,7 +1271,7 @@ class VTApp(QtCore.QObject):
         buttons_box.accepted.connect(versions_dlg.accept)
 
         versions_edit.setReadOnly(1)
-        versions_edit.setText(\
+        versions_edit.setText(
             """
             <qt>
             <h3>{title}</h3>

--- a/vitables/vtapp.py
+++ b/vitables/vtapp.py
@@ -252,7 +252,7 @@ class VTApp(QtCore.QObject):
             for nodepath in item:  # '/group1/group2/...groupN/leaf'
                 # Check if the node still exists because the database
                 # could have changed since last ViTables session
-                node = db_doc.getNode(nodepath)
+                node = db_doc.get_node(nodepath)
                 if node is None:
                     continue
                 # groups is ['', 'group1', 'group2', ..., 'groupN']
@@ -543,7 +543,7 @@ class VTApp(QtCore.QObject):
         try:
             QtGui.qApp.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
             dbdoc = self.gui.dbs_tree_model.getDBDoc(initial_filepath)
-            dbdoc.copyFile(filepath)
+            dbdoc.copy_file(filepath)
         finally:
             QtGui.qApp.restoreOverrideCursor()
 
@@ -838,10 +838,10 @@ class VTApp(QtCore.QObject):
         # If the creation overwrites a group with attached views then these
         # views are closed before the renaming is done
         if overwrite:
-            nodepath = tables.path.joinPath(parent.nodepath, nodename)
+            nodepath = tables.path.join_path(parent.nodepath, nodename)
             self.gui.closeChildrenViews(nodepath, parent.filepath)
 
-        self.gui.dbs_tree_model.createGroup(current, nodename, overwrite)
+        self.gui.dbs_tree_model.create_group(current, nodename, overwrite)
 
 
     def nodeRename(self):
@@ -897,11 +897,11 @@ class VTApp(QtCore.QObject):
         # If the renaming overwrites a node with attached views then these
         # views are closed before the renaming is done
         if overwrite:
-            nodepath = tables.path.joinPath(parent.nodepath, nodename)
+            nodepath = tables.path.join_path(parent.nodepath, nodename)
             self.gui.closeChildrenViews(nodepath, child.filepath)
 
         # Rename the node
-        self.gui.dbs_tree_model.renameNode(index, nodename, overwrite)
+        self.gui.dbs_tree_model.rename_node(index, nodename, overwrite)
 
         # Update the Selected node indicator of the status bar
         self.gui.updateStatusBar()
@@ -948,7 +948,7 @@ class VTApp(QtCore.QObject):
                     return
 
         # Copy the node
-        self.gui.dbs_tree_model.copyNode(current)
+        self.gui.dbs_tree_model.copy_node(current)
 
 
     def nodePaste(self):
@@ -1014,7 +1014,7 @@ class VTApp(QtCore.QObject):
         # If the pasting overwrites a node with attached views then these
         # views are closed before the pasting is done
         if overwrite:
-            nodepath = tables.path.joinPath(parent.nodepath, nodename)
+            nodepath = tables.path.join_path(parent.nodepath, nodename)
             self.gui.closeChildrenViews(nodepath, parent.filepath)
 
         # Paste the node
@@ -1251,7 +1251,7 @@ class VTApp(QtCore.QObject):
         # Add new items to the dictionary
         libraries = ('HDF5', 'Zlib', 'LZO', 'BZIP2')
         for lib in libraries:
-            lversion = tables.whichLibVersion(lib.lower())
+            lversion = tables.which_lib_version(lib.lower())
             if lversion:
                 libs_versions[lib] = lversion[1]
             else:

--- a/vitables/vtgui.py
+++ b/vitables/vtgui.py
@@ -925,8 +925,8 @@ class VTGUI(QtGui.QMainWindow):
                 # If active mdi subwindow can handle context menu
                 # pass the event to it
                 active_window = self.workspace.activeSubWindow()
-                if active_window is not None \
-                   and hasattr(active_window, 'is_context_menu_custom'):
+                if active_window is not None and \
+                        hasattr(active_window, 'is_context_menu_custom'):
                     is_cm_custom = active_window.is_context_menu_custom
                 else:
                     is_cm_custom = False

--- a/vitables/vttables/leaf_delegate.py
+++ b/vitables/vttables/leaf_delegate.py
@@ -70,7 +70,7 @@ class LeafDelegate(QtGui.QStyledItemDelegate):
             buffer_start = model.rbuffer.start
             cell = index.model().selected_cell
             if ((index == cell['index']) and \
-            (buffer_start != cell['buffer_start'])):
+                    (buffer_start != cell['buffer_start'])):
                 painter.save()
                 self.initStyleOption(option, index)
                 background = option.palette.color(QtGui.QPalette.Base)

--- a/vitables/vttables/leaf_model.py
+++ b/vitables/vttables/leaf_model.py
@@ -46,8 +46,8 @@ def get_enum_column_description(data_source):
     for _, column_description in data_source.coldescrs.items():
         if not isinstance(column_description, tables.EnumCol):
             continue
-        enum_columns[column_description._v_pos] \
-            = {value: name for name, value in column_description.enum}
+        enum_columns[column_description._v_pos] = \
+            {value: name for name, value in column_description.enum}
     return enum_columns
 
 

--- a/vitables/vttables/leaf_view.py
+++ b/vitables/vttables/leaf_view.py
@@ -104,7 +104,7 @@ class LeafView(QtGui.QTableView):
 
         # Connect signals to slots
         if self.leaf_numrows > self.tmodel.numrows:
-            self.tricky_vscrollbar.actionTriggered.connect(\
+            self.tricky_vscrollbar.actionTriggered.connect(
                 self.navigateWithMouse)
 
 
@@ -409,7 +409,7 @@ class LeafView(QtGui.QTableView):
             start = 0
             position = 0
             hint = QtGui.QAbstractItemView.PositionAtTop
-            self.vscrollbar.triggerAction(\
+            self.vscrollbar.triggerAction(
                 QtGui.QAbstractSlider.SliderToMinimum)
         else:
             start = row - table_rows
@@ -438,7 +438,7 @@ class LeafView(QtGui.QTableView):
             start = self.leaf_numrows - table_rows
             position = table_rows - 1
             hint = QtGui.QAbstractItemView.PositionAtBottom
-            self.vscrollbar.triggerAction(\
+            self.vscrollbar.triggerAction(
                 QtGui.QAbstractSlider.SliderToMinimum)
         else:
             start = row
@@ -487,7 +487,7 @@ class LeafView(QtGui.QTableView):
         # row of the dataset we still can go downwards so we have to
         # read the next contiguous buffer
         if (last_vp_row + self.wheel_step + 1 > table_rows) and \
-            (buffer_start + table_rows < self.leaf_numrows):
+                (buffer_start + table_rows < self.leaf_numrows):
             # Buffer fault. The new buffer and the old one overlap to ensure
             # that no jumps occur.
             new_start = \
@@ -708,7 +708,7 @@ class LeafView(QtGui.QTableView):
         # row of the dataset we still can go downwards so we have to
         # read the next contiguous buffer
         if (buffer_row == table_rows - 1) and \
-            (buffer_start + table_rows < self.leaf_numrows):
+                (buffer_start + table_rows < self.leaf_numrows):
             model.loadData(dataset_row - page_step + 1, table_rows)
             self.updateView()
             # The position of the new current row
@@ -741,7 +741,7 @@ class LeafView(QtGui.QTableView):
         # row of the dataset we still can go downwards so we have to
         # read the next contiguous buffer
         if (buffer_row + page_step > table_rows - 1) and \
-            (buffer_start + table_rows < self.leaf_numrows):
+                (buffer_start + table_rows < self.leaf_numrows):
             model.loadData(dataset_row + 1, table_rows)
             self.updateView()
             # The position of the new current row

--- a/vitables/vtwidgets/renamedlg.py
+++ b/vitables/vtwidgets/renamedlg.py
@@ -119,7 +119,7 @@ class RenameDlg(QtGui.QDialog, Ui_RenameNodeDialog):
             translate('RenameDlg', 'Rename', 'A button label'),
             QtGui.QDialogButtonBox.AcceptRole)
         self.rename_button.setDefault(1)
-        self.cancel_button = self.buttonsBox.button(\
+        self.cancel_button = self.buttonsBox.button(
             QtGui.QDialogButtonBox.Cancel)
 
         # Setup a validator for checking the entered node name
@@ -168,8 +168,8 @@ class RenameDlg(QtGui.QDialog, Ui_RenameNodeDialog):
         # group 1 of the pattern is matched
         result = self.cpattern.search(new_name)
         if (result == None) or \
-            ((result != None) and (result.lastindex == 1)) or \
-            (not new_name):
+                ((result != None) and (result.lastindex == 1)) or \
+                (not new_name):
             self.rename_button.setEnabled(0)
             self.overwrite_button.setEnabled(0)
         elif new_name == self.troubled_name:

--- a/vitables/vtwidgets/renamedlg.py
+++ b/vitables/vtwidgets/renamedlg.py
@@ -191,7 +191,7 @@ class RenameDlg(QtGui.QDialog, Ui_RenameNodeDialog):
         """
 
         if button == self.rename_button:
-            self.renameNode()
+            self.rename_node()
         elif button == self.overwrite_button:
             self.overwriteNode()
 
@@ -209,7 +209,7 @@ class RenameDlg(QtGui.QDialog, Ui_RenameNodeDialog):
         self.accept()
 
 
-    def renameNode(self):
+    def rename_node(self):
         """
         Set the new name and exit.
 


### PR DESCRIPTION
ViTables no longer works with the latest PyTables which drops the old PyTables 2 syntax.
- Use pt2to3 to update to the new PyTables 3 syntax.
- Additionally update line continuation to use implied continuation instead of backslashes, where applicable.
