### PR TITLE
Resolve Minor Errors in Using Calculator

### DIFF
--- a/vitables/calculator/calculator.py
+++ b/vitables/calculator/calculator.py
@@ -210,9 +210,15 @@ class CalculatorDialog(qtgui.QDialog, Ui_CalculatorDialog):
         selected_index = self.saved_list.selectedIndexes()[0]
         name = self.saved_list.itemFromIndex(selected_index).text()
         statements, expression, destination = self._name_expression_dict[name]
-        self.statements_edit.setText(statements)
-        self.expression_edit.setText(expression)
-        self.result_edit.setText(destination)
+        self.statements_edit.setText(
+            statements if statements is not None else ''
+        )
+        self.expression_edit.setText(
+            expression if expression is not None else ''
+        )
+        self.result_edit.setText(
+            destination if destination is not None else ''
+        )
 
     def _store_expressions(self):
         """Store expressions in configuration.

--- a/vitables/calculator/calculator.py
+++ b/vitables/calculator/calculator.py
@@ -207,7 +207,15 @@ class CalculatorDialog(qtgui.QDialog, Ui_CalculatorDialog):
         dictionary and update expression and result widgets.
 
         """
-        selected_index = self.saved_list.selectedIndexes()[0]
+        selected_indexes = self.saved_list.selectedIndexes()
+        if len(selected_indexes) == 0:
+            # KFP 2015-08-04: There is a race condition when removing a
+            # stored expression.  Both this method and
+            # ``on_remove_button_clicked`` are called very close to the
+            # same time meaning ``self.saved_list.count()`` can show the
+            # wrong value.
+            return
+        selected_index = selected_indexes[0]
         name = self.saved_list.itemFromIndex(selected_index).text()
         statements, expression, destination = self._name_expression_dict[name]
         self.statements_edit.setText(

--- a/vitables/calculator/calculator.py
+++ b/vitables/calculator/calculator.py
@@ -164,7 +164,12 @@ class CalculatorDialog(qtgui.QDialog, Ui_CalculatorDialog):
         dictionary.
 
         """
-        current_name = self.saved_list.currentItem().text()
+        current_item = self.saved_list.currentItem()
+        if current_item is None:
+            # Either the list is empty or nothing is selected.
+            current_name = ""
+        else:
+            current_name = current_item.text()
         name, is_accepted = qtgui.QInputDialog.getText(
             self, translate('Calculator', 'Save expression as'),
             translate('Calculator', 'Name:'), text=current_name)

--- a/vitables/calculator/calculator.py
+++ b/vitables/calculator/calculator.py
@@ -352,8 +352,11 @@ class CalculatorDialog(qtgui.QDialog, Ui_CalculatorDialog):
                 translate('Calculator', 'An exception was raised during '
                           'evaluation, see log for details.'))
             return False
-        if not isinstance(result, np.ndarray) and not isinstance(result, list):
-            result = np.array([result])
+        if not isinstance(result, np.ndarray):
+            if isinstance(result, (list, tuple)):
+                result = np.array(result)
+            else:
+                result = np.array([result])
         try:
             result_group._v_file.create_array(
                 result_group, result_name, obj=result,

--- a/vitables/calculator/calculator.py
+++ b/vitables/calculator/calculator.py
@@ -189,7 +189,15 @@ class CalculatorDialog(qtgui.QDialog, Ui_CalculatorDialog):
         dictionary.
 
         """
-        removed_item = self.saved_list.takeItem(self.saved_list.currentRow())
+        current_row = self.saved_list.currentRow()
+        if current_row < 0:
+            qtgui.QMessageBox.warning(
+                self, translate('Calculator', 'Nothing selected'),
+                translate('Calculator', 'No saved expression selected '
+                          'to be removed.'))
+            return
+        removed_item = self.saved_list.takeItem(
+                self.saved_list.currentRow())
         del self._name_expression_dict[removed_item.text()]
 
     def on_saved_list_itemSelectionChanged(self):


### PR DESCRIPTION
Exploring the use of the Calculator feature, I came across a few bugs in the runtime.  First, was that lists are not considered valid return types from the expression field.  This is due to the native Python types being removed as valid PyTables flavors on line 49 of vitables/vttables/buffers.py.  The second and third patches resolve an issue with checking a `NoneType` for the `text` method when the saved expressions list is empty and either the save or remove button is clicked.  

The fourth patch gracefully handles when the statements, expressions, or result table field is empty and the expression is saved.  It checks for `None` and replaces it with the empty string when the expression is reloaded.  The idea was to allow the user to incrementally save while working on a complex statement (or in my case when I kept hitting ESC to exit out of insert mode when I'm not in vim and accidentally exiting the window ;-).

The final patch handles a race condition I found when removing the final item expression from the saved expressions list.  It appears that `on_remove_button_clicked` and `on_saved_list_itemSelectionChanged` are dispatched almost simultaneously when the remove button is clicked.  This means `count` does not show that the list is to be emptied.  The way I was able to reproduce this condition is to put print statements at the start and end of both functions and try adding and removing expressions.  With luck, one came up with the statements interleaved.

This is a wonderfully handy tool!  I was starting to think about how to do essentially this same task for the visualizing 3D arrays.  I did wind up having to poke around with it to try to understand what it was doing.  I wasn't able to find any particular documentation on the tool, so I started taking notes.  I collected the salient points into a [wiki page](https://github.com/kprussing/ViTables/wiki/Doing-Calculations-with-Leaves).  Any feedback on the clarity there would be greatly appreciated.  I didn't want to include that as part of the explicit pull request because I would like feedback on the clarity.