### PR TITLE
FIX #63: regression by pt2to3 tool miss-converting create_index()

### DIFF
--- a/vitables/h5db/dbstreemodel.py
+++ b/vitables/h5db/dbstreemodel.py
@@ -912,7 +912,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
             group = self.nodeFromIndex(parent)
             try:
                 node = group.childAtRow(row)
-                return self.create_index(row, column, node)
+                return self.createIndex(row, column, node)
             except IndexError:
                 return QtCore.QModelIndex()
         return QtCore.QModelIndex()
@@ -944,7 +944,7 @@ class DBsTreeModel(QtCore.QAbstractItemModel):
             return QtCore.QModelIndex()
         grandparent = parent.parent
         row = grandparent.rowOfChild(parent)
-        return self.create_index(row, 0, parent)
+        return self.createIndex(row, 0, parent)
 
     def lazyAddChildren(self, index):
         """Add children to a group node when it is expanded.


### PR DESCRIPTION
Revert regression by ff0555c where `pt2to3` tool miss-detected `DBsTreeModel.createIndex()` as belonging to *tables* API, and converting it to create_index().