### PR TITLE
WIP refact(table): decouple buffer from table-view by moving paging up to model

### DIFF
--- a/vitables/plugins/columnorg/columnar_org.py
+++ b/vitables/plugins/columnorg/columnar_org.py
@@ -146,7 +146,7 @@ class ArrayColsOrganizer(QtCore.QObject):
                 'folder': os.path.join(os.path.dirname(__file__)),
                 'author': 'Vicent Mas <vmas@vitables.org>',
                 'comment': translate('ArrayColsOrganizer',
-                    """
+                                     """
                     <qt><p>Plugin that provides an alternative view for
                     arrays with the same number of rows. <p>
                     The user has to open all the arrays she whishes to see in
@@ -158,7 +158,7 @@ class ArrayColsOrganizer(QtCore.QObject):
                     <p>Note that all ticked arrays must have the same
                     dimensions for the `Group` menu item to enable.</qt>
                     """,
-                    'Text of an About plugin message box')}
+                                     'Text of an About plugin message box')}
         about_page = AboutPage(desc, parent)
         return about_page
 
@@ -198,10 +198,10 @@ class MenuUpdater(QtCore.QObject):
             triggered=self.groupArrays,
             icon=object_group_icon,
             statusTip=translate('MenuUpdater',
-                """
+                                """
                 Use a unique widget to display Arrays as if
                 they where columns of a Table""",
-                "Status bar text for the Node -> Group Arrays action"))
+                                "Status bar text for the Node -> Group Arrays action"))
 
         object_ungroup_icon = QtGui.QIcon()
         pixmap = QtGui.QPixmap(os.path.join(_PLUGIN_FOLDER,
@@ -219,8 +219,8 @@ class MenuUpdater(QtCore.QObject):
             triggered=self.ungroupArrays,
             icon=object_ungroup_icon,
             statusTip=translate('MenuUpdater',
-                """Ungroup previously grouped arrays.""",
-                "Status bar text for the Node -> Ungroup Arrays action"))
+                                """Ungroup previously grouped arrays.""",
+                                "Status bar text for the Node -> Ungroup Arrays action"))
 
         # Add the actions to the Node menu
         vitables.utils.addToMenu(self.vtgui.node_menu, (self.group_action,
@@ -468,12 +468,12 @@ class GroupedArrays(QtWidgets.QMdiSubWindow):
 
         nd = len(datasheets)
         for i in range(nd):
-            datasheets[nd-1].widget().verticalScrollBar().valueChanged.connect(
+            datasheets[nd - 1].widget().verticalScrollBar().valueChanged.connect(
                 datasheets[i].widget().verticalScrollBar().setValue)
             if i < (nd - 1):
                 datasheets[i].widget().verticalScrollBar().hide()
                 datasheets[i].widget().setCornerWidget(None)
-                datasheets[i+1].widget().verticalHeader().hide()
+                datasheets[i + 1].widget().verticalHeader().hide()
 
     def closeEvent(self, event):
         """ Propagate the close event.

--- a/vitables/plugins/timeseries/time_series.py
+++ b/vitables/plugins/timeseries/time_series.py
@@ -231,7 +231,7 @@ class TSFormatter(object):
             leaf_kind = 'array'
         model_info = {
             'leaf_kind': leaf_kind,
-            'rbuffer': model.rbuffer,
+            'model': model,
             'numrows': model.rowCount(),
             'formatContent': model.formatContent,
         }
@@ -298,7 +298,7 @@ class TSLeafModel(object):
         self.ts_freq = ts_info['ts_freq']
         self.ts_format = ts_info['ts_format']
         # Attributes required by the data() method
-        self.rbuffer = model_info['rbuffer']
+        self.model = model_info['model']
         self.numrows = model_info['numrows']
         self.ts_cols = ts_info['ts_cols']
         self.formatContent = model_info['formatContent']
@@ -322,12 +322,13 @@ class TSLeafModel(object):
         - `index`: the index of a data item
         - `role`: the role being returned
         """
+        row, col = index.row(), index.column()
 
-        if not index.isValid() or not (0 <= index.row() < self.nrows):
+        if not index.isValid() or not (0 <= row < self.nrows):
             return None
 
         if role == QtCore.Qt.DisplayRole:
-            cell = self.rbuffer.getCell(index.row(), index.column())
+            cell = self.model.cell(row, col)
             if index.column() in self.ts_cols:
                 return self.tsFormatter(cell)
             return self.formatContent(cell)
@@ -348,12 +349,13 @@ class TSLeafModel(object):
         - `index`: the index of a data item
         - `role`: the role being returned
         """
+        row, col = index.row(), index.column()
 
-        if not index.isValid() or not (0 <= index.row() < self.nrows):
+        if not index.isValid() or not (0 <= row < self.nrows):
             return None
 
         if role == QtCore.Qt.DisplayRole:
-            cell = self.rbuffer.getCell(index.row(), index.column())
+            cell = self.model.cell(row, col)
             return self.tsFormatter(cell)
 
         if role == QtCore.Qt.TextAlignmentRole:

--- a/vitables/plugins/timeseries/time_series.py
+++ b/vitables/plugins/timeseries/time_series.py
@@ -50,7 +50,6 @@ except ImportError:
     pd = None
 
 from qtpy import QtCore
-from qtpy import QtGui
 from qtpy import QtWidgets
 
 import vitables.utils
@@ -152,7 +151,7 @@ def tsFrequency(ts_kind, leaf):
     if ts_kind == 'scikits_ts':
         # The frequency of the time serie. Default is 6000 (daily)
         special_attrs = getattr(leaf._v_attrs, 'special_attrs',
-            {'freq': 6000})
+                                {'freq': 6000})
         ts_freq = special_attrs['freq']
     return ts_freq
 
@@ -225,7 +224,7 @@ class TSFormatter(object):
             'ts_cols': time_cols,
             'ts_freq': tsFrequency(ts_kind, leaf),
             'ts_format': datetimeFormat(),
-            }
+        }
         if isinstance(leaf, tables.Table):
             leaf_kind = 'table'
         else:
@@ -246,7 +245,6 @@ class TSFormatter(object):
         model.tsFormatter = ts_model.tsFormatter
         model.data = ts_model.data
 
-
     def helpAbout(self, parent):
         """Full description of the plugin.
 
@@ -260,17 +258,17 @@ class TSFormatter(object):
 
         # Plugin full description
         desc = {'version': __version__,
-            'module_name': os.path.join(os.path.basename(__file__)),
-            'folder': os.path.join(os.path.dirname(__file__)),
-            'author': 'Vicent Mas <vmas@vitables.org>',
-            'about_text': translate('TimeFormatterPage',
-            """<qt>
+                'module_name': os.path.join(os.path.basename(__file__)),
+                'folder': os.path.join(os.path.dirname(__file__)),
+                'author': 'Vicent Mas <vmas@vitables.org>',
+                'about_text': translate('TimeFormatterPage',
+                                        """<qt>
             <p>Plugin that provides nice string formatting for time fields.
             <p>It supports not only native PyTables time datatypes but
             also time series generated (and stored in PyTables tables) via
             Pandas and scikits.timeseries packages.
             </qt>""",
-            'Text of an About plugin message box')}
+                                        'Text of an About plugin message box')}
         self.about_page = AboutPage(desc, parent)
 
         # We need to install the event filter because the Preferences dialog
@@ -313,7 +311,6 @@ class TSLeafModel(object):
         else:
             self.data = self.array_data
 
-
     def table_data(self, index, role=QtCore.Qt.DisplayRole):
         """Returns the data stored under the given role for the item
         referred to by the index.
@@ -340,7 +337,6 @@ class TSLeafModel(object):
 
         return None
 
-
     def array_data(self, index, role=QtCore.Qt.DisplayRole):
         """Returns the data stored under the given role for the item
         referred to by the index.
@@ -361,10 +357,9 @@ class TSLeafModel(object):
             return self.tsFormatter(cell)
 
         if role == QtCore.Qt.TextAlignmentRole:
-            return QtCore.Qt.AlignLeft|QtCore.Qt.AlignTop
+            return QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop
 
         return None
-
 
     def timeFormatter(self):
         """Return the function to be used for formatting time series.
@@ -379,7 +374,6 @@ class TSLeafModel(object):
         elif ts_kind == 'pytables_ts':
             time_formatter = self.formatPyTablesTS
         return time_formatter
-
 
     def formatPyTablesTS(self, content):
         """
@@ -396,7 +390,6 @@ class TSLeafModel(object):
         except ValueError:
             return content
 
-
     def formatPandasTS(self, content):
         """Format a given date in a user friendly way.
 
@@ -405,13 +398,12 @@ class TSLeafModel(object):
 
         :Parameter content: the content of the table cell being formatted
         """
-
+        # ImportError if pandas not installed!
         date = pd.Timestamp(int(content))
         try:
             return date.strftime(self.ts_format)
         except ValueError:
             return content
-
 
     def formatScikitsTS(self, content):
         """Format a given date in a user friendly way.

--- a/vitables/plugins/timeseries/time_series.py
+++ b/vitables/plugins/timeseries/time_series.py
@@ -326,18 +326,18 @@ class TSLeafModel(object):
         - `role`: the role being returned
         """
 
-        if not index.isValid() or not (0 <= index.row() < self.numrows):
+        if not index.isValid() or not (0 <= index.row() < self.nrows):
             return None
-        
+
         if role == QtCore.Qt.DisplayRole:
             cell = self.rbuffer.getCell(index.row(), index.column())
             if index.column() in self.ts_cols:
                 return self.tsFormatter(cell)
             return self.formatContent(cell)
-        
+
         if role == QtCore.Qt.TextAlignmentRole:
             return QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop
-        
+
         return None
 
 
@@ -353,7 +353,7 @@ class TSLeafModel(object):
         - `role`: the role being returned
         """
 
-        if not index.isValid() or not (0 <= index.row() < self.numrows):
+        if not index.isValid() or not (0 <= index.row() < self.nrows):
             return None
 
         if role == QtCore.Qt.DisplayRole:

--- a/vitables/plugins/timeseries/time_series.py
+++ b/vitables/plugins/timeseries/time_series.py
@@ -329,8 +329,7 @@ class TSLeafModel(object):
         if not index.isValid() or \
             not (0 <= index.row() < self.numrows):
             return None
-        cell = self.rbuffer.getCell(self.rbuffer.start + index.row(),
-            index.column())
+        cell = self.rbuffer.getCell(index.row(), index.column())
         if role == QtCore.Qt.DisplayRole:
             if index.column() in self.ts_cols:
                 return self.tsFormatter(cell)
@@ -356,8 +355,7 @@ class TSLeafModel(object):
         if not index.isValid() or \
             not (0 <= index.row() < self.numrows):
             return None
-        cell = self.rbuffer.getCell(self.rbuffer.start + index.row(),
-            index.column())
+        cell = self.rbuffer.getCell(index.row(), index.column())
         if role == QtCore.Qt.DisplayRole:
             return self.tsFormatter(cell)
         elif role == QtCore.Qt.TextAlignmentRole:

--- a/vitables/plugins/timeseries/time_series.py
+++ b/vitables/plugins/timeseries/time_series.py
@@ -326,18 +326,19 @@ class TSLeafModel(object):
         - `role`: the role being returned
         """
 
-        if not index.isValid() or \
-            not (0 <= index.row() < self.numrows):
+        if not index.isValid() or not (0 <= index.row() < self.numrows):
             return None
-        cell = self.rbuffer.getCell(index.row(), index.column())
+        
         if role == QtCore.Qt.DisplayRole:
+            cell = self.rbuffer.getCell(index.row(), index.column())
             if index.column() in self.ts_cols:
                 return self.tsFormatter(cell)
             return self.formatContent(cell)
-        elif role == QtCore.Qt.TextAlignmentRole:
-            return int(QtCore.Qt.AlignLeft|QtCore.Qt.AlignTop)
-        else:
-            return None
+        
+        if role == QtCore.Qt.TextAlignmentRole:
+            return QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop
+        
+        return None
 
 
     def array_data(self, index, role=QtCore.Qt.DisplayRole):
@@ -352,16 +353,17 @@ class TSLeafModel(object):
         - `role`: the role being returned
         """
 
-        if not index.isValid() or \
-            not (0 <= index.row() < self.numrows):
+        if not index.isValid() or not (0 <= index.row() < self.numrows):
             return None
-        cell = self.rbuffer.getCell(index.row(), index.column())
+
         if role == QtCore.Qt.DisplayRole:
+            cell = self.rbuffer.getCell(index.row(), index.column())
             return self.tsFormatter(cell)
-        elif role == QtCore.Qt.TextAlignmentRole:
-            return int(QtCore.Qt.AlignLeft|QtCore.Qt.AlignTop)
-        else:
-            return None
+
+        if role == QtCore.Qt.TextAlignmentRole:
+            return QtCore.Qt.AlignLeft|QtCore.Qt.AlignTop
+
+        return None
 
 
     def timeFormatter(self):

--- a/vitables/vttables/buffer.py
+++ b/vitables/vttables/buffer.py
@@ -48,6 +48,8 @@ tables.restrict_flavors(keep=['numpy'])
 warnings.filterwarnings('ignore', category=tables.FlavorWarning)
 warnings.filterwarnings('ignore', category=tables.NaturalNameWarning)
 
+log = logging.getLogger(__name__)
+
 
 class Buffer(object):
     """Buffer used to access the real data contained in `PyTables` datasets.
@@ -80,9 +82,6 @@ class Buffer(object):
         """
         Initializes the buffer.
         """
-
-        self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(logging.INFO)
 
         self.leaf = leaf
 
@@ -161,7 +160,7 @@ class Buffer(object):
         except tables.HDF5ExtError:
             readable = False
             # TODO: Fix error msg to include exception or merge with below.
-            self.logger.error(
+            log.error(
                 translate('Buffer',
                           """Problems reading records. The dataset """
                           """seems to be compressed with the {0} library. """
@@ -171,7 +170,7 @@ class Buffer(object):
                               self.leaf.filters.complib))
         except ValueError as e:
             readable = False
-            self.logger.error(
+            log.error(
                 translate('Buffer', 'Data read error: {}',
                           'A dataset read error').format(e.message))
         return readable
@@ -204,7 +203,7 @@ class Buffer(object):
             data = self.leaf.read(start, stop)
         except tables.HDF5ExtError:
             # TODO: Fix error msg to include exception.
-            self.logger.error(
+            log.error(
                 translate('Buffer', """\nError: problems reading records. """
                           """The dataset maybe corrupted.""",
                           'A dataset readability error'))
@@ -228,12 +227,7 @@ class Buffer(object):
 
         :Returns: the cell at position `(row, col)` of the document
         """
-
-        try:
-            return self.chunk[()]
-        except IndexError:
-            self.logger.error('IndexError! row, column: {1}, {2}'
-                              .format(row, col))
+        return self.chunk[()]
 
     def vectorCell(self, row, col):
         """
@@ -260,11 +254,7 @@ class Buffer(object):
         # get the right chunk element.
         # chunk = [row0, row1, row2, ..., rowN]
         # and columns can be read from a given row using indexing notation
-        try:
-            return self.chunk[row]
-        except IndexError:
-            self.logger.error('IndexError! row, column: {1}, {2}'
-                              .format(row, col))
+        return self.chunk[row]
 
     def EArrayCell(self, row, col):
         """
@@ -287,11 +277,7 @@ class Buffer(object):
         # and columns can be read from a given row using indexing notation
         # TODO: this method should be improved as it requires to read the
         # whola array keeping the read data in memory
-        try:
-            return self.leaf.read()[row]
-        except IndexError:
-            self.logger.error('IndexError! row, column: {1}, {2}'
-                              .format(row, col))
+        return self.leaf.read()[row]
 
     def arrayCell(self, row, col):
         """
@@ -316,8 +302,4 @@ class Buffer(object):
         # For tables we have
         # chunk = [nestedrecord0, nestedrecord1, ..., nestedrecordN]
         # and fields can be read from nestedrecordJ using indexing notation
-        try:
-            return self.chunk[row][col]
-        except IndexError:
-            self.logger.error('IndexError! row, column: {1}, {2}'
-                              .format(row, col))
+        return self.chunk[row][col]

--- a/vitables/vttables/buffer.py
+++ b/vitables/vttables/buffer.py
@@ -92,18 +92,14 @@ class Buffer(object):
         # The maximum number of rows to be read from the data source
         self.chunk_size = 10000
 
-        # The length of the dimension that is going to be read. It
-        # is an int64.
+        # The length of the dimension that is going to be read.
         self.leaf_numrows = self.leafNumberOfRows()
         if self.leaf_numrows <= self.chunk_size:
             self.chunk_size = self.leaf_numrows
 
         # The numpy array where read data will be stored
         self.chunk = numpy.array([])
-
-        # The document row where the current chunk of data starts.
-        # It must be an int64 in order to address spaces bigger than 2**32
-        self.start = numpy.array(0, dtype=numpy.int64)
+        self.start = 0
 
         # The method used for reading data depends on the kind of node.
         # Setting the reader method at initialization time increases the
@@ -160,7 +156,7 @@ class Buffer(object):
         else:
             nrows = self.data_source.nrows
 
-        return numpy.array(nrows, dtype=numpy.int64)
+        return nrows
 
     def getReadParameters(self, start, buffer_size):
         """
@@ -169,14 +165,13 @@ class Buffer(object):
         :Parameters:
 
         - `start`: the document row that is the first row of the chunk.
-          It *must* be a 64 bits integer.
         - `buffer_size`: the buffer size, i.e. the number of rows to be read.
 
         :Returns:
             a tuple with tested values for the parameters of the read method
         """
 
-        first_row = numpy.array(0, dtype=numpy.int64)
+        first_row = 0
         last_row = self.leaf_numrows
 
         # When scrolling up we must keep start value >= first_row
@@ -203,7 +198,7 @@ class Buffer(object):
         """
 
         readable = True
-        start, stop = self.getReadParameters(numpy.array(0, dtype=numpy.int64),
+        start, stop = self.getReadParameters(0,
                                              self.chunk_size)
         try:
             self.data_source.read(start, stop)
@@ -240,7 +235,6 @@ class Buffer(object):
         :Parameters:
 
         - `start`: the document row that is the first row of the chunk.
-          It *must* be a 64 bits integer.
         - `buffer_size`: the buffer size, i.e. the number of rows to be read.
         """
 
@@ -273,7 +267,7 @@ class Buffer(object):
 
         :Parameters:
 
-        - `row`: the row to which the cell belongs. It is a 64 bits integer
+        - `row`: the row to which the cell belongs.
         - `col`: the column to wich the cell belongs
 
         :Returns: the cell at position `(row, col)` of the document
@@ -300,16 +294,14 @@ class Buffer(object):
 
         :Parameters:
 
-        - `row`: the row to which the cell belongs. It is a 64 bits integer
+        - `row`: the row to which the cell belongs.
         - `col`: the column to wich the cell belongs
 
         :Returns: the cell at position `(row, col)` of the document
         """
 
         # We must shift the row value by self.start units in order to
-        # get the right chunk element. Note that indices of chunk
-        # needn't to be int64 because they are indexing a fixed size,
-        # small chunk of data (see ctor docstring).
+        # get the right chunk element.
         # chunk = [row0, row1, row2, ..., rowN]
         # and columns can be read from a given row using indexing notation
         try:
@@ -327,16 +319,14 @@ class Buffer(object):
 
         :Parameters:
 
-        - `row`: the row to which the cell belongs. It is a 64 bits integer
+        - `row`: the row to which the cell belongs.
         - `col`: the column to wich the cell belongs
 
         :Returns: the cell at position `(row, col)` of the document
         """
 
         # We must shift the row value by self.start units in order to
-        # get the right chunk element. Note that indices of chunk
-        # needn't to be int64 because they are indexing a fixed size,
-        # small chunk of data (see ctor docstring).
+        # get the right chunk element.
         # chunk = [row0, row1, row2, ..., rowN]
         # and columns can be read from a given row using indexing notation
         # TODO: this method should be improved as it requires to read the
@@ -356,16 +346,14 @@ class Buffer(object):
 
         :Parameters:
 
-        - `row`: the row to which the cell belongs. It is a 64 bits integer
+        - `row`: the row to which the cell belongs.
         - `col`: the column to wich the cell belongs
 
         :Returns: the cell at position `(row, col)` of the document
         """
 
         # We must shift the row value by self.start units in order to get the
-        # right chunk element. Note that indices of chunk needn't to be
-        # int64 because they are indexing a fixed size, small chunk of
-        # data (see ctor docstring).
+        # right chunk element.
         # For arrays we have
         # chunk = [row0, row1, row2, ..., rowN]
         # and columns can be read from a given row using indexing notation

--- a/vitables/vttables/buffer.py
+++ b/vitables/vttables/buffer.py
@@ -87,7 +87,7 @@ class Buffer(object):
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.INFO)
 
-        self.data_source = leaf
+        self.leaf = leaf
 
         # The maximum number of rows to be read from the data source
         self.chunk_size = 10000
@@ -142,19 +142,19 @@ class Buffer(object):
         :Returns: the size of the first dimension of the document
         """
 
-        shape = self.data_source.shape
+        shape = self.leaf.shape
         if shape is None:
             # Node is not a Leaf or there was problems getting the shape
             nrows = 0
         elif shape == ():
             # Node is a rank 0 array (e.g. numpy.array(5))
             nrows = 1
-        elif isinstance(self.data_source, tables.EArray):
+        elif isinstance(self.leaf, tables.EArray):
             # Warning: the number of rows of an EArray, ea, can be different
             # from the number of rows of the numpy array ea.read()
-            nrows = self.data_source.shape[0]
+            nrows = self.leaf.shape[0]
         else:
-            nrows = self.data_source.nrows
+            nrows = self.leaf.nrows
 
         return nrows
 
@@ -199,7 +199,7 @@ class Buffer(object):
 
         readable = True
         try:
-            self.data_source.read(0, 1)
+            self.leaf.read(0, 1)
         except tables.HDF5ExtError:
             readable = False
             ## TODO: Fix error msg to include exception.
@@ -210,7 +210,7 @@ class Buffer(object):
                           """Check that it is installed in your system, """
                           """please.""",
                           'A dataset readability error').format(
-                              self.data_source.filters.complib))
+                              self.leaf.filters.complib))
         except ValueError as e:
             readable = False
             self.logger.error(
@@ -244,7 +244,7 @@ class Buffer(object):
             # Warning: in a EArray with shape (2,3,3) and extdim attribute
             # being 1, the read method will have 3 rows. However, the numpy
             # array returned by EArray.read() will have only 2 rows
-            data = self.data_source.read(start, stop)
+            data = self.leaf.read(start, stop)
         except tables.HDF5ExtError:
             ## TODO: Fix error msg to include exception.
             self.logger.error(
@@ -332,7 +332,7 @@ class Buffer(object):
         # TODO: this method should be improved as it requires to read the
         # whola array keeping the read data in memory
         try:
-            return self.data_source.read()[row]
+            return self.leaf.read()[row]
         except IndexError:
             self.logger.error('IndexError! buffer start: {0} row, column: '
                               '{1}, {2}'.format(self.start, row, col))

--- a/vitables/vttables/buffer.py
+++ b/vitables/vttables/buffer.py
@@ -198,12 +198,11 @@ class Buffer(object):
         """
 
         readable = True
-        start, stop = self.getReadParameters(0,
-                                             self.chunk_size)
         try:
-            self.data_source.read(start, stop)
+            self.data_source.read(0, 1)
         except tables.HDF5ExtError:
             readable = False
+            ## TODO: Fix error msg to include exception.
             self.logger.error(
                 translate('Buffer',
                           """Problems reading records. The dataset """
@@ -247,6 +246,7 @@ class Buffer(object):
             # array returned by EArray.read() will have only 2 rows
             data = self.data_source.read(start, stop)
         except tables.HDF5ExtError:
+            ## TODO: Fix error msg to include exception.
             self.logger.error(
                 translate('Buffer', """\nError: problems reading records. """
                           """The dataset maybe corrupted.""",

--- a/vitables/vttables/buffer.py
+++ b/vitables/vttables/buffer.py
@@ -300,12 +300,12 @@ class Buffer(object):
         :Returns: the cell at position `(row, col)` of the document
         """
 
-        # We must shift the row value by self.start units in order to
+        # The row-coordinate must be shifted by model.start units in order to
         # get the right chunk element.
         # chunk = [row0, row1, row2, ..., rowN]
         # and columns can be read from a given row using indexing notation
         try:
-            return self.chunk[int(row - self.start)]
+            return self.chunk[row]
         except IndexError:
             self.logger.error('IndexError! buffer start: {0} row, column: '
                               '{1}, {2}'.format(self.start, row, col))
@@ -325,14 +325,14 @@ class Buffer(object):
         :Returns: the cell at position `(row, col)` of the document
         """
 
-        # We must shift the row value by self.start units in order to
+        # The row-coordinate must be shifted by model.start units in order to
         # get the right chunk element.
         # chunk = [row0, row1, row2, ..., rowN]
         # and columns can be read from a given row using indexing notation
         # TODO: this method should be improved as it requires to read the
         # whola array keeping the read data in memory
         try:
-            return self.data_source.read()[int(row - self.start)]
+            return self.data_source.read()[row]
         except IndexError:
             self.logger.error('IndexError! buffer start: {0} row, column: '
                               '{1}, {2}'.format(self.start, row, col))
@@ -352,8 +352,8 @@ class Buffer(object):
         :Returns: the cell at position `(row, col)` of the document
         """
 
-        # We must shift the row value by self.start units in order to get the
-        # right chunk element.
+        # The row-coordinate must be shifted by model.start units in order to
+        # get the right chunk element.
         # For arrays we have
         # chunk = [row0, row1, row2, ..., rowN]
         # and columns can be read from a given row using indexing notation
@@ -361,7 +361,7 @@ class Buffer(object):
         # chunk = [nestedrecord0, nestedrecord1, ..., nestedrecordN]
         # and fields can be read from nestedrecordJ using indexing notation
         try:
-            return self.chunk[int(row - self.start)][col]
+            return self.chunk[row][col]
         except IndexError:
             self.logger.error('IndexError! buffer start: {0} row, column: '
                               '{1}, {2}'.format(self.start, row, col))

--- a/vitables/vttables/datasheet.py
+++ b/vitables/vttables/datasheet.py
@@ -37,7 +37,7 @@ import vitables.nodeprops.nodeinfo as nodeinfo
 import vitables.vtwidgets.zoom_cell as zoom_cell
 import vitables.vttables.leaf_model as leaf_model
 import vitables.vttables.leaf_view as leaf_view
-import vitables.vttables.buffer as readBuffer
+
 
 class DataSheet(QtWidgets.QMdiSubWindow):
     """
@@ -67,8 +67,7 @@ class DataSheet(QtWidgets.QMdiSubWindow):
         else:
             leaf = pt_node
 
-        rbuffer = readBuffer.Buffer(leaf)
-        self.leaf_model = leaf_model.LeafModel(rbuffer)
+        self.leaf_model = leaf_model.LeafModel(leaf)
         self.leaf_view = leaf_view.LeafView(self.leaf_model)
 
         super(DataSheet, self).__init__(self.vtgui.workspace,
@@ -162,10 +161,10 @@ class DataSheet(QtWidgets.QMdiSubWindow):
         if node.node_kind == 'table':
             col = info.columns_names[column]
             title = '{0}: {1}[{2}]'.format(node.name, col,
-                tmodel.rbuffer.start + row)
+                tmodel.start + row)
         else:
             title = '{0}: ({1},{2})'.format(node.name,
-                tmodel.rbuffer.start + row, column)
+                tmodel.start + row, column)
 
         zoom_cell.ZoomCell(data, title, self.vtgui.workspace,
                           self.dbt_leaf)

--- a/vitables/vttables/datasheet.py
+++ b/vitables/vttables/datasheet.py
@@ -94,7 +94,6 @@ class DataSheet(QtWidgets.QMdiSubWindow):
         self.aboutToActivate.connect(self.syncTreeView)
         self.leaf_view.doubleClicked.connect(self.zoomCell)
 
-
     def closeEvent(self, event):
         """Close the window cleanly with the close button of the title bar.
 
@@ -112,7 +111,6 @@ class DataSheet(QtWidgets.QMdiSubWindow):
         if self.vtgui.workspace.subWindowList() == []:
             self.vtgui.dbs_tree_view.setFocus(True)
 
-
     def focusInEvent(self, event):
         """Specialised handler for focus events.
 
@@ -128,7 +126,6 @@ class DataSheet(QtWidgets.QMdiSubWindow):
         self.syncTreeView()
         self.setFocus(True)
 
-
     def syncTreeView(self):
         """
         If the view is activated select its leaf in the tree of databases view.
@@ -143,7 +140,6 @@ class DataSheet(QtWidgets.QMdiSubWindow):
         self.vtgui.dbs_tree_view.setCurrentIndex(
             QtCore.QModelIndex(self.pindex))
 
-
     def zoomCell(self, index):
         """Display the inner dimensions of a cell.
 
@@ -153,7 +149,7 @@ class DataSheet(QtWidgets.QMdiSubWindow):
         row = index.row()
         column = index.column()
         tmodel = index.model()
-        data = tmodel.rbuffer.getCell(row, column)
+        data = tmodel.cell(row, column)
 
         # The title of the zoomed view
         node = self.dbt_leaf
@@ -161,10 +157,10 @@ class DataSheet(QtWidgets.QMdiSubWindow):
         if node.node_kind == 'table':
             col = info.columns_names[column]
             title = '{0}: {1}[{2}]'.format(node.name, col,
-                tmodel.start + row)
+                                           tmodel.start + row)
         else:
             title = '{0}: ({1},{2})'.format(node.name,
-                tmodel.start + row, column)
+                                            tmodel.start + row, column)
 
         zoom_cell.ZoomCell(data, title, self.vtgui.workspace,
-                          self.dbt_leaf)
+                           self.dbt_leaf)

--- a/vitables/vttables/datasheet.py
+++ b/vitables/vttables/datasheet.py
@@ -154,7 +154,7 @@ class DataSheet(QtWidgets.QMdiSubWindow):
         row = index.row()
         column = index.column()
         tmodel = index.model()
-        data = tmodel.rbuffer.getCell(tmodel.rbuffer.start + row, column)
+        data = tmodel.rbuffer.getCell(row, column)
 
         # The title of the zoomed view
         node = self.dbt_leaf

--- a/vitables/vttables/datasheet.py
+++ b/vitables/vttables/datasheet.py
@@ -150,6 +150,8 @@ class DataSheet(QtWidgets.QMdiSubWindow):
         column = index.column()
         tmodel = index.model()
         data = tmodel.cell(row, column)
+        if data is None:
+            return
 
         # The title of the zoomed view
         node = self.dbt_leaf

--- a/vitables/vttables/leaf_delegate.py
+++ b/vitables/vttables/leaf_delegate.py
@@ -67,7 +67,7 @@ class LeafDelegate(QtWidgets.QStyledItemDelegate):
         # option.state is an ORed combination of flags
         if (option.state & QtWidgets.QStyle.State_Selected):
             model = index.model()
-            buffer_start = model.rbuffer.start
+            buffer_start = model.start
             cell = index.model().selected_cell
             if ((index == cell['index']) and \
                     (buffer_start != cell['buffer_start'])):

--- a/vitables/vttables/leaf_model.py
+++ b/vitables/vttables/leaf_model.py
@@ -26,16 +26,18 @@ in a `tables.Leaf`.
 
 __docformat__ = 'restructuredtext'
 
+import logging
 import vitables.utils
+from vitables.vttables import buffer
 
 from qtpy import QtCore
 import tables
 
-from vitables.vttables import buffer
-
 
 #: The maximum number of rows to be read from the data source.
 CHUNK_SIZE = 10000
+
+log = logging.getLogger(__name__)
 
 
 class LeafModel(QtCore.QAbstractTableModel):
@@ -212,15 +214,28 @@ class LeafModel(QtCore.QAbstractTableModel):
         - `index`: the index of a data item
         - `role`: the role being returned
         """
+        row, col = index.row(), index.column()
 
-        if not index.isValid() or not (0 <= index.row() < self.numrows):
+        if not index.isValid() or not (0 <= row < self.numrows):
             return None
 
         if role == QtCore.Qt.DisplayRole:
-            cell = self.rbuffer.getCell(index.row(), index.column())
+            cell = self.cell(row, col)
             return self.formatContent(cell)
 
         if role == QtCore.Qt.TextAlignmentRole:
             return QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop
 
         return None
+
+    def cell(self, row, col):
+        """
+        Returns the contents of a cell.
+
+        :return: none to disable zooming.
+        """
+        try:
+            return self.rbuffer.getCell(row, col)
+        except IndexError:
+            log.error('IndexError! buffer start: {0} row, column: '
+                      '{1}, {2}'.format(self.start, row, col))

--- a/vitables/vttables/leaf_model.py
+++ b/vitables/vttables/leaf_model.py
@@ -54,7 +54,7 @@ class LeafModel(QtCore.QAbstractTableModel):
         """
 
         # The model data source (a PyTables/HDF5 leaf) and its access buffer
-        self.data_source = rbuffer.data_source
+        self.leaf = rbuffer.leaf
         self.rbuffer = rbuffer
 
         # The number of digits of the last row
@@ -74,14 +74,14 @@ class LeafModel(QtCore.QAbstractTableModel):
         # The dataset number of columns doesn't use to be large so, we don't
         # need set a maximum as we did with rows. The whole set of columns
         # are displayed
-        if isinstance(self.data_source, tables.Table):
+        if isinstance(self.leaf, tables.Table):
             # Leaf is a PyTables table
-            self.numcols = len(self.data_source.colnames)
-        elif isinstance(self.data_source, tables.EArray):
+            self.numcols = len(self.leaf.colnames)
+        elif isinstance(self.leaf, tables.EArray):
             self.numcols = 1
         else:
             # Leaf is some kind of PyTables array
-            shape = self.data_source.shape
+            shape = self.leaf.shape
             if len(shape) > 1:
                 # The leaf will be displayed as a bidimensional matrix
                 self.numcols = shape[1]
@@ -98,9 +98,9 @@ class LeafModel(QtCore.QAbstractTableModel):
         # Time series (if they are found) are formatted transparently
         # via the time_series.py plugin
 
-        if not isinstance(self.data_source, tables.Table):
+        if not isinstance(self.leaf, tables.Table):
             # Leaf is some kind of PyTables array
-            atom_type = self.data_source.atom.type
+            atom_type = self.leaf.atom.type
             if atom_type == 'object':
                 self.formatContent = vitables.utils.formatObjectContent
             elif atom_type in ('vlstring', 'vlunicode'):
@@ -143,8 +143,8 @@ class LeafModel(QtCore.QAbstractTableModel):
         if orientation == QtCore.Qt.Horizontal:
             # For tables horizontal labels are column names, for arrays
             # the section numbers are used as horizontal labels
-            if hasattr(self.data_source, 'description'):
-                return str(self.data_source.colnames[section])
+            if hasattr(self.leaf, 'description'):
+                return str(self.leaf.colnames[section])
             return str(section)
 
         ## Rows-labels

--- a/vitables/vttables/leaf_model.py
+++ b/vitables/vttables/leaf_model.py
@@ -133,20 +133,22 @@ class LeafModel(QtCore.QAbstractTableModel):
         # The section alignment
         if role == QtCore.Qt.TextAlignmentRole:
             if orientation == QtCore.Qt.Horizontal:
-                return int(QtCore.Qt.AlignLeft|QtCore.Qt.AlignVCenter)
-            return int(QtCore.Qt.AlignRight|QtCore.Qt.AlignVCenter)
+                return QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter
+            return QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter
+
         if role != QtCore.Qt.DisplayRole:
             return None
-        # The section label for horizontal header
+
+        ## Columns-labels
         if orientation == QtCore.Qt.Horizontal:
             # For tables horizontal labels are column names, for arrays
             # the section numbers are used as horizontal labels
             if hasattr(self.data_source, 'description'):
                 return str(self.data_source.colnames[section])
             return str(section)
-        # The section label for vertical header. This is a 64 bits integer
-        return str(self.rbuffer.start + section)
 
+        ## Rows-labels
+        return str(self.rbuffer.start + section)
 
     def data(self, index, role=QtCore.Qt.DisplayRole):
         """Returns the data stored under the given role for the item
@@ -162,14 +164,15 @@ class LeafModel(QtCore.QAbstractTableModel):
 
         if not index.isValid() or not (0 <= index.row() < self.numrows):
             return None
-        cell = self.rbuffer.getCell(index.row(), index.column())
-        if role == QtCore.Qt.DisplayRole:
-            return self.formatContent(cell)
-        elif role == QtCore.Qt.TextAlignmentRole:
-            return int(QtCore.Qt.AlignLeft|QtCore.Qt.AlignTop)
-        else:
-            return None
 
+        if role == QtCore.Qt.DisplayRole:
+            cell = self.rbuffer.getCell(index.row(), index.column())
+            return self.formatContent(cell)
+
+        if role == QtCore.Qt.TextAlignmentRole:
+            return QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop
+
+        return None
 
     def columnCount(self, index=QtCore.QModelIndex()):
         """The number of columns of the given model index.

--- a/vitables/vttables/leaf_model.py
+++ b/vitables/vttables/leaf_model.py
@@ -114,9 +114,6 @@ class LeafModel(QtCore.QAbstractTableModel):
 
         super(LeafModel, self).__init__(parent)
 
-    def _collect_enum_indices(self):
-        """Initialize structures required to properly display enum columns."""
-
     def headerData(self, section, orientation, role):
         """Returns the data for the given role and section in the header
         with the specified orientation.

--- a/vitables/vttables/leaf_model.py
+++ b/vitables/vttables/leaf_model.py
@@ -162,8 +162,7 @@ class LeafModel(QtCore.QAbstractTableModel):
 
         if not index.isValid() or not (0 <= index.row() < self.numrows):
             return None
-        cell = self.rbuffer.getCell(self.rbuffer.start + index.row(),
-                                    index.column())
+        cell = self.rbuffer.getCell(index.row(), index.column())
         if role == QtCore.Qt.DisplayRole:
             return self.formatContent(cell)
         elif role == QtCore.Qt.TextAlignmentRole:

--- a/vitables/vttables/leaf_view.py
+++ b/vitables/vttables/leaf_view.py
@@ -288,8 +288,8 @@ class LeafView(QtWidgets.QTableView):
             # last row of the viewport.
             model.loadData(
                 buffer_start + page_step - table_rows, table_rows)
-            self.scrollTo(
-                model.index(buffer_start + page_step - model.start - 1, 0),
+            self.scrollTo(model.index(
+                buffer_start + page_step - model.start - 1, 0),
                 QtWidgets.QAbstractItemView.PositionAtBottom)
             self.updateView()
         else:

--- a/vitables/vttables/leaf_view.py
+++ b/vitables/vttables/leaf_view.py
@@ -144,8 +144,7 @@ class LeafView(QtWidgets.QTableView):
         # rows and row equals to value
         interval_size = 1
         if self.max_value < self.leaf_numrows:
-            interval_size = numpy.rint(numpy.array(
-                self.leaf_numrows/self.max_value, dtype=numpy.int64))
+            interval_size = round(self.leaf_numrows / self.max_value)
         return interval_size
 
 
@@ -166,8 +165,7 @@ class LeafView(QtWidgets.QTableView):
         elif fv_label == 1 :
             self.tricky_vscrollbar.setValue(0)
         else :
-            value = numpy.rint(numpy.array(fv_label/self.interval_size,
-                dtype=numpy.float64))
+            value = round(fv_label / self.interval_size)
             self.tricky_vscrollbar.setValue(value)
 
 
@@ -372,7 +370,7 @@ class LeafView(QtWidgets.QTableView):
             value = self.max_value
             row = self.leaf_numrows - 1
         else :
-            row = numpy.array(self.interval_size*value, dtype=numpy.int64)
+            row = self.interval_size * value
 
         # top buffer fault condition
         if row < model.rbuffer.start:
@@ -465,8 +463,7 @@ class LeafView(QtWidgets.QTableView):
             # has been rotated by 15 degrees. It *seems* that every eight of
             # degree corresponds to a distance of 1 pixel.
             delta = event.angleDelta().y()
-            self.wheel_step = \
-                numpy.rint(abs(delta)/height).astype(numpy.int64) - 1
+            self.wheel_step = round(abs(delta) / height) - 1
             if delta < 0:
                 self.wheelDown(event)
             else:

--- a/vitables/vttables/leaf_view.py
+++ b/vitables/vttables/leaf_view.py
@@ -38,8 +38,11 @@ from qtpy import QtCore
 from qtpy import QtGui
 from qtpy import QtWidgets
 
-import vitables.vttables.scrollbar as scrollbar
 import vitables.vttables.leaf_delegate as leaf_delegate
+import vitables.vttables.scrollbar as scrollbar
+
+
+_aiv = QtWidgets.QAbstractItemView
 
 
 class LeafView(QtWidgets.QTableView):
@@ -63,11 +66,11 @@ class LeafView(QtWidgets.QTableView):
         self.tmodel = tmodel  # This is a MUST
         self.leaf_numrows = leaf_numrows = self.tmodel.leaf_numrows
         self.selection_model = self.selectionModel()
-        self.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
-        self.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectItems)
+        self.setSelectionMode(_aiv.SingleSelection)
+        self.setSelectionBehavior(_aiv.SelectItems)
 
         # Setup the actual vertical scrollbar
-        self.setVerticalScrollMode(QtWidgets.QAbstractItemView.ScrollPerItem)
+        self.setVerticalScrollMode(_aiv.ScrollPerItem)
         self.vscrollbar = self.verticalScrollBar()
 
         self.setModel(tmodel)
@@ -196,7 +199,7 @@ class LeafView(QtWidgets.QTableView):
             4: self.subPageStep,
             7: self.dragSlider
         }
-        if not slider_action in actions.keys():
+        if slider_action not in actions.keys():
             return
         # Navigate the data dealing with buffer faults
         actions[slider_action]()
@@ -248,7 +251,7 @@ class LeafView(QtWidgets.QTableView):
             self.updateView()
             self.scrollTo(
                 model.index(new_start - model.start, 0),
-                QtWidgets.QAbstractItemView.PositionAtTop)
+                _aiv.PositionAtTop)
         else:
             self.vscrollbar.triggerAction(1)
 
@@ -270,7 +273,7 @@ class LeafView(QtWidgets.QTableView):
             self.updateView()
             self.scrollTo(
                 model.index(new_start - model.start, 0),
-                QtWidgets.QAbstractItemView.PositionAtTop)
+                _aiv.PositionAtTop)
         else:
             self.vscrollbar.triggerAction(3)
 
@@ -288,9 +291,9 @@ class LeafView(QtWidgets.QTableView):
             # last row of the viewport.
             model.loadData(
                 buffer_start + page_step - table_rows, table_rows)
-            self.scrollTo(model.index(
-                buffer_start + page_step - model.start - 1, 0),
-                QtWidgets.QAbstractItemView.PositionAtBottom)
+            self.scrollTo(
+                model.index(buffer_start + page_step - model.start - 1, 0),
+                _aiv.PositionAtBottom)
             self.updateView()
         else:
             self.vscrollbar.triggerAction(2)
@@ -314,7 +317,7 @@ class LeafView(QtWidgets.QTableView):
             self.scrollTo(
                 model.index(
                     buffer_start + first_vp_row - model.start, 0),
-                QtWidgets.QAbstractItemView.PositionAtBottom)
+                _aiv.PositionAtBottom)
         else:
             self.vscrollbar.triggerAction(4)
 
@@ -365,7 +368,7 @@ class LeafView(QtWidgets.QTableView):
         else:
             self.scrollTo(
                 model.index(row - model.start, 0),
-                QtWidgets.QAbstractItemView.PositionAtTop)
+                _aiv.PositionAtTop)
 
     def topBF(self, value, row):
         """Going out of buffer when browsing upwards.
@@ -382,13 +385,13 @@ class LeafView(QtWidgets.QTableView):
         if value == self.tricky_vscrollbar.minimum():
             start = 0
             position = 0
-            hint = QtWidgets.QAbstractItemView.PositionAtTop
+            hint = _aiv.PositionAtTop
             self.vscrollbar.triggerAction(
                 QtWidgets.QAbstractSlider.SliderToMinimum)
         else:
             start = row - table_rows
             position = table_rows - 1
-            hint = QtWidgets.QAbstractItemView.PositionAtBottom
+            hint = _aiv.PositionAtBottom
 
         self.tmodel.loadData(start, table_rows)
         self.updateView()
@@ -410,13 +413,13 @@ class LeafView(QtWidgets.QTableView):
             row = self.leaf_numrows - 1
             start = self.leaf_numrows - table_rows
             position = table_rows - 1
-            hint = QtWidgets.QAbstractItemView.PositionAtBottom
+            hint = _aiv.PositionAtBottom
             self.vscrollbar.triggerAction(
                 QtWidgets.QAbstractSlider.SliderToMinimum)
         else:
             start = row
             position = 0
-            hint = QtWidgets.QAbstractItemView.PositionAtTop
+            hint = _aiv.PositionAtTop
 
         self.tmodel.loadData(start, table_rows)
         self.updateView()
@@ -465,7 +468,7 @@ class LeafView(QtWidgets.QTableView):
             model.loadData(new_start, table_rows)
             self.updateView()
             self.scrollTo(model.index(new_start - model.start, 0),
-                          QtWidgets.QAbstractItemView.PositionAtTop)
+                          _aiv.PositionAtTop)
         else:
             QtCore.QCoreApplication.sendEvent(self.vscrollbar, event)
 
@@ -489,7 +492,7 @@ class LeafView(QtWidgets.QTableView):
             self.scrollTo(
                 model.index(
                     new_start + table_rows - model.start - 1, 0),
-                QtWidgets.QAbstractItemView.PositionAtBottom)
+                _aiv.PositionAtBottom)
         else:
             QtCore.QCoreApplication.sendEvent(self.vscrollbar, event)
 
@@ -616,7 +619,7 @@ class LeafView(QtWidgets.QTableView):
             index = model.index(row, buffer_column)
             self.setCurrentIndex(index)
             self.scrollTo(index,
-                          QtWidgets.QAbstractItemView.PositionAtTop)
+                          _aiv.PositionAtTop)
         else:
             QtWidgets.QTableView.keyPressEvent(self, event)
 
@@ -647,7 +650,7 @@ class LeafView(QtWidgets.QTableView):
             index = model.index(row, buffer_column)
             self.setCurrentIndex(index)
             self.scrollTo(index,
-                          QtWidgets.QAbstractItemView.PositionAtTop)
+                          _aiv.PositionAtTop)
         else:
             QtWidgets.QTableView.keyPressEvent(self, event)
 
@@ -679,7 +682,7 @@ class LeafView(QtWidgets.QTableView):
             index = model.index(row, buffer_column)
             self.setCurrentIndex(index)
             self.scrollTo(index,
-                          QtWidgets.QAbstractItemView.PositionAtBottom)
+                          _aiv.PositionAtBottom)
         else:
             QtWidgets.QTableView.keyPressEvent(self, event)
 
@@ -711,7 +714,7 @@ class LeafView(QtWidgets.QTableView):
             index = model.index(row, buffer_column)
             self.setCurrentIndex(index)
             self.scrollTo(index,
-                          QtWidgets.QAbstractItemView.PositionAtBottom)
+                          _aiv.PositionAtBottom)
         else:
             QtWidgets.QTableView.keyPressEvent(self, event)
 

--- a/vitables/vttables/scrollbar.py
+++ b/vitables/vttables/scrollbar.py
@@ -33,11 +33,12 @@ datasets with a larger number of rows than that provided by the view widget.
 
 __docformat__ = 'restructuredtext'
 
-from qtpy import QtCore
-from qtpy import QtGui
-from qtpy import QtWidgets
+from qtpy.QtCore import Qt
+from qtpy.QtCore import QEvent
+from qtpy.QtWidgets import QScrollBar
 
-class ScrollBar(QtWidgets.QScrollBar):
+
+class ScrollBar(QScrollBar):
     """
     A specialised scrollbar for views of huge datasets.
 
@@ -60,15 +61,19 @@ class ScrollBar(QtWidgets.QScrollBar):
         super(ScrollBar, self).__init__(parent)
         view.vscrollbar.setVisible(False)
         parent.layout().addWidget(self)
-        self.setOrientation(QtCore.Qt.Vertical)
+        self.setOrientation(Qt.Vertical)
         self.setObjectName('tricky_vscrollbar')
 
-
     def event(self, e):
-        """Filter wheel events and send them to the table viewport.
-        """
-
-        if (e.type() == QtCore.QEvent.Wheel):
+        """Filter wheel events and send them to the table viewport. """
+        if (e.type() == QEvent.Wheel):
             self.view.wheelEvent(e)
             return True
-        return QtWidgets.QScrollBar.event(self, e)
+        return QScrollBar.event(self, e)
+
+    def setMaxValue(self, max_value):
+        """Ensure range of scrollbar is a signed 32bit integer."""
+        max_value = min(2 ** 31 - 1, max_value)
+        self.setMaximum(max_value)
+
+        return max_value


### PR DESCRIPTION
I want to add a new feature that will display *pandas dataframes*(see #35), but I had problems factoring out a clean table model that exposes the dataframe cells. In the process I realized that the table `vitables.vttables` classes `LeafView/LeafModel/Buffer` were highly coupled, without clear responsibilities.
This PR restructures model & buffer according to these guidelines:

+ Encapsulate buffer so as to be accessed only by model by dropping or moving buffer's *paging* fields *UP* into model:
  + Move `start/nrows/chunk_size` attributes up, from buffer-->model.
  + Merge `model.chunk_size` with `nrows` in model - they served the same purpose
  + Move up & merge `buffer.getReadParameters()`-->`model.loadData()`.
+ Minor speedups (e.g. don't fetch cell-data if not display-role).
+ Stop using `np.int64` for long tables - python ints are just as fine.
+ PEP8 & moderate renaming of variables (e.g. `data_set`-->`leaf`).
+ Apply (partially ) good practices on logging- reuse module loggers on new objects , don't set log-level in code.

## WIP: 
- I started gradually implementing the refactorings, hopefully separated in small chunks.
- The move/merge of variables from buffer --> model had to be done in one commit.
- There are some more methods to move *down* from model to buffer regarding total-columns.  
- What is really left is *testing*, ensuring plugins work correctly, and documenting the new setup in the class docstrings and possibly in the docs  of the project.
- Any help, particularly for the testing would be welcomed.

(when it is finished, the `'WIP'` has to be removed from this PR's title.)