### PR TITLE
Enable starting with python -m vitables

### DIFF
--- a/vitables/__main__.py
+++ b/vitables/__main__.py
@@ -1,0 +1,4 @@
+from vitables.start import gui
+
+gui()
+


### PR DESCRIPTION
This is motivated by the `vitables` command seemingly not working on Windows, and it's easier to to do `python -m vitables` than have to remember that it should be `python -m vitables.start`.