### PR TITLE
Finally fixing #83 (blank fields)

### DIFF
--- a/vitables/vttables/leaf_model.py
+++ b/vitables/vttables/leaf_model.py
@@ -123,8 +123,10 @@ class LeafModel(QtCore.QAbstractTableModel):
                 self.formatContent = vitables.utils.formatObjectContent
             elif atom_type in ('vlstring', 'vlunicode'):
                 self.formatContent = vitables.utils.formatStringContent
+            else:
+                self.formatContent = vitables.utils.formatArrayContent
         else:
-            self.formatContent = vitables.utils.formatStringContent
+            self.formatContent = vitables.utils.formatArrayContent
 
         # Track selected cell
         self.selected_cell = {'index': QtCore.QModelIndex(), 'buffer_start': 0}


### PR DESCRIPTION
This is a follow-up pull request. The last last time I was in a hurry and fixed it for ```EArray```, ```CArray```, etc., but broke it for ```table.Table```.