### PR TITLE
Update collection path for Python 3.8+.

### DIFF
--- a/vitables/utils.py
+++ b/vitables/utils.py
@@ -149,7 +149,7 @@ def insertInMenu(menu, entries, uid):
     :return: None
     """
 
-    if not isinstance(entries, collections.Iterable):
+    if not isinstance(entries, collections.abc.Iterable):
         entries = [entries]
 
     if isinstance(entries[0], QtWidgets.QAction):
@@ -177,7 +177,7 @@ def addToMenu(menu, entries):
     :return: None
     """
 
-    if not isinstance(entries, collections.Iterable):
+    if not isinstance(entries, collections.abc.Iterable):
         entries = [entries]
 
     if isinstance(entries[0], QtWidgets.QAction):


### PR DESCRIPTION
Starting from Python 3.8, `collections.Iterable` is only available as `collections.abc.Iterable` (before it was deprecated). This fixes those paths to make ViTables run under newer Python versions.