### PR TITLE
Fix version information display

### DIFF
--- a/vitables/vtapp.py
+++ b/vitables/vtapp.py
@@ -27,6 +27,7 @@ import time
 import sys
 import logging
 
+import numpy
 import tables
 
 from qtpy import QtCore
@@ -1246,7 +1247,7 @@ class VTApp(QtCore.QObject):
                                'Caption of the Versions dialog'),
             'Python': pyversion,
             'PyTables': tables.__version__,
-            'NumPy': tables.numpy.__version__,
+            'NumPy': numpy.__version__,
             'Qt': QtCore.qVersion(),
             'PyQt': QtCore.PYQT_VERSION_STR,
             'ViTables': vtconfig.getVersion()


### PR DESCRIPTION
PyTables has changed how numpy is imported in this PR:
https://github.com/PyTables/PyTables/pull/864
As a result, in PyTables 3.7.0+, `tables.numpy.__version__` will raise an error:
> module 'tables' has no attribute 'numpy'

![Screenshot 2022-03-14 174126](https://user-images.githubusercontent.com/5435649/158148927-1152a4e3-3a9f-4038-8037-79890d66f334.png)
With this patch, the version information dialog can display correctly:
![Screenshot 2022-03-14 174348](https://user-images.githubusercontent.com/5435649/158149092-5daf546e-4d01-47c1-b47c-2d4603d860c9.png)
