### PR TITLE
Accidentally dropped pyqt5 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-install_requires = ['qtpy', 'pyqt6', 'numpy (>=1.4.1)', 'numexpr (>=2.0)',
+install_requires = ['qtpy', 'numpy (>=1.4.1)', 'numexpr (>=2.0)',
                     'tables (>=3.0)', 'setuptools']
 
 setup(name='ViTables',


### PR DESCRIPTION
In the last PR #119 I added pyqt6 which dropped support for pyqt5. This shouldn't have happened.

pls review @uvemas 