### PR TITLE
Support numpy version 2

### DIFF
--- a/vitables/csv/csvutils.py
+++ b/vitables/csv/csvutils.py
@@ -36,7 +36,7 @@ import tables
 
 # https://github.com/numpy/numpy/issues/10990
 import warnings
-warnings.filterwarnings("ignore", category=numpy.VisibleDeprecationWarning)
+warnings.filterwarnings("ignore", category=numpy.exceptions.VisibleDeprecationWarning)
 
 
 translate = QtWidgets.QApplication.translate

--- a/vitables/nodeprops/attrpropdlg.py
+++ b/vitables/nodeprops/attrpropdlg.py
@@ -133,7 +133,7 @@ class AttrPropDlg(QtWidgets.QDialog, Ui_AttrPropDialog):
             # isinstance(asi.test, int) returns True
             # asi.test.shape returns ()
             # asi.test2 = "hello" ->
-            # type(asi.test2) returns numpy.string_
+            # type(asi.test2) returns numpy.bytes_
             # isinstance(asi.test2, str) returns True
             # asi.test2.shape returns ()
             # Beware that objects whose shape is () are not warranted

--- a/vitables/utils.py
+++ b/vitables/utils.py
@@ -453,7 +453,7 @@ def formatArrayContent(content):
     :Parameter content: the ``numpy`` array contained in the view cell
     """
 
-    if isinstance(content, numpy.string_):
+    if isinstance(content, numpy.bytes_):
         try:
             return content.decode(DEFAULT_ENCODING)
         except UnicodeDecodeError:


### PR DESCRIPTION
Vitables breaks with numpy>=2 due to a few renamed/moved classes. These are all that I could find.